### PR TITLE
Allow the file fetcher to change the default maxAge if no cache-control header is defined.

### DIFF
--- a/lib/src/file_fetcher.dart
+++ b/lib/src/file_fetcher.dart
@@ -17,9 +17,26 @@ abstract class FileFetcherResponse {
 
   bool hasHeader(String name);
   String header(String name);
+
+  /// return the maxAge the response might be cached.
+  /// By default returns the max-age of cache-control header.
+  Duration get maxAge {
+    if (hasHeader("cache-control")) {
+      var cacheControl = header("cache-control");
+      var controlSettings = cacheControl.split(", ");
+      final setting = controlSettings.firstWhere((setting) => setting.contains('max-age'), orElse: () => null);
+      if (setting != null) {
+        final validSeconds = int.tryParse(setting.split("=")[1]) ?? 0;
+        if (validSeconds > 0) {
+          return new Duration(seconds: validSeconds);
+        }
+      }
+    }
+    return null;
+  }
 }
 
-class HttpFileFetcherResponse implements FileFetcherResponse {
+class HttpFileFetcherResponse extends FileFetcherResponse {
   http.Response _response;
 
   HttpFileFetcherResponse(this._response);

--- a/lib/src/web_helper.dart
+++ b/lib/src/web_helper.dart
@@ -106,25 +106,9 @@ class WebHelper {
     return false;
   }
 
-  _setDataFromHeaders(
-      CacheObject cacheObject, FileFetcherResponse response) async {
-    //Without a cache-control header we keep the file for a week
-    var ageDuration = new Duration(days: 7);
-
-    if (response.hasHeader("cache-control")) {
-      var cacheControl = response.header("cache-control");
-      var controlSettings = cacheControl.split(", ");
-      controlSettings.forEach((setting) {
-        if (setting.startsWith("max-age=")) {
-          var validSeconds = int.tryParse(setting.split("=")[1]) ?? 0;
-          if (validSeconds > 0) {
-            ageDuration = new Duration(seconds: validSeconds);
-          }
-        }
-      });
-    }
-
-    cacheObject.validTill = new DateTime.now().add(ageDuration);
+  _setDataFromHeaders(CacheObject cacheObject, FileFetcherResponse response) async {
+    // Without a valid cache-control header we keep the file for a week
+    cacheObject.validTill = DateTime.now().add(response.maxAge ?? const Duration(days: 7));
 
     if (response.hasHeader("etag")) {
       cacheObject.eTag = response.header("etag");


### PR DESCRIPTION
I use the cache manager also for JSON responses for api endpoints, and those return max-age=0, which I can't change. So right now those are cached 7 days by default. It would be nice to make this configurable.

This PR makes the `FileFetcherResponse` responsible for parsing the `cache-control` header, and so the FileFetcher can actually specify how long it should stay in cache. for example for my use case I'm using:

```dart
  static const defaultJsonMaxAge = Duration(hours: 1);

  String get contentType => header(HttpHeaders.contentTypeHeader);

  // If response is a json response, and max-age is zero, make sure it is cached for (no more than) 1 hour.
  // (the cache manager will otherwise default to 7 days.)
  @override
  Duration get maxAge =>
      super.maxAge ??
      (contentType?.contains('json') == true ? const Duration(hours: 1) : null);
```

Note that this might be a breaking change, if others have used `implements FileFetcherResponse` instead of `extends`.