### PR TITLE
Make `cleanupRunMinInterval` and `CacheObjectProvider` mockable

### DIFF
--- a/lib/src/cache_object.dart
+++ b/lib/src/cache_object.dart
@@ -5,6 +5,7 @@
 // HINT: Unnecessary import. Future and Stream are available via dart:core.
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:sqflite/sqflite.dart';
 
 final String tableCacheObject = "cacheObject";
@@ -66,6 +67,9 @@ class CacheObject {
 }
 
 class CacheObjectProvider {
+  @visibleForTesting
+  static DateTime Function() now = () => DateTime.now();
+
   Database db;
   String path;
 
@@ -134,9 +138,7 @@ class CacheObjectProvider {
         columns: null,
         orderBy: "$columnTouched ASC",
         where: "$columnTouched < ?",
-        whereArgs: [
-          DateTime.now().subtract(new Duration(days: 1)).millisecondsSinceEpoch
-        ],
+        whereArgs: [now().subtract(new Duration(days: 1)).millisecondsSinceEpoch],
         limit: 100,
         offset: capacity);
 
@@ -148,7 +150,7 @@ class CacheObjectProvider {
       tableCacheObject,
       where: "$columnTouched < ?",
       columns: null,
-      whereArgs: [DateTime.now().subtract(maxAge).millisecondsSinceEpoch],
+      whereArgs: [now().subtract(maxAge).millisecondsSinceEpoch],
       limit: 100,
     );
 

--- a/lib/src/cache_object.dart
+++ b/lib/src/cache_object.dart
@@ -5,7 +5,6 @@
 // HINT: Unnecessary import. Future and Stream are available via dart:core.
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:sqflite/sqflite.dart';
 
 final String tableCacheObject = "cacheObject";
@@ -67,9 +66,6 @@ class CacheObject {
 }
 
 class CacheObjectProvider {
-  @visibleForTesting
-  static DateTime Function() now = () => DateTime.now();
-
   Database db;
   String path;
 
@@ -138,7 +134,9 @@ class CacheObjectProvider {
         columns: null,
         orderBy: "$columnTouched ASC",
         where: "$columnTouched < ?",
-        whereArgs: [now().subtract(new Duration(days: 1)).millisecondsSinceEpoch],
+        whereArgs: [
+          DateTime.now().subtract(new Duration(days: 1)).millisecondsSinceEpoch
+        ],
         limit: 100,
         offset: capacity);
 
@@ -150,7 +148,7 @@ class CacheObjectProvider {
       tableCacheObject,
       where: "$columnTouched < ?",
       columns: null,
-      whereArgs: [now().subtract(maxAge).millisecondsSinceEpoch],
+      whereArgs: [DateTime.now().subtract(maxAge).millisecondsSinceEpoch],
       limit: 100,
     );
 

--- a/lib/src/cache_object.dart
+++ b/lib/src/cache_object.dart
@@ -5,6 +5,7 @@
 // HINT: Unnecessary import. Future and Stream are available via dart:core.
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:sqflite/sqflite.dart';
 
 final String tableCacheObject = "cacheObject";
@@ -68,6 +69,9 @@ class CacheObject {
 class CacheObjectProvider {
   Database db;
   String path;
+
+  @protected
+  DateTime get now => DateTime.now();
 
   CacheObjectProvider(this.path);
 
@@ -135,7 +139,7 @@ class CacheObjectProvider {
         orderBy: "$columnTouched ASC",
         where: "$columnTouched < ?",
         whereArgs: [
-          DateTime.now().subtract(new Duration(days: 1)).millisecondsSinceEpoch
+          now.subtract(new Duration(days: 1)).millisecondsSinceEpoch
         ],
         limit: 100,
         offset: capacity);
@@ -148,7 +152,7 @@ class CacheObjectProvider {
       tableCacheObject,
       where: "$columnTouched < ?",
       columns: null,
-      whereArgs: [DateTime.now().subtract(maxAge).millisecondsSinceEpoch],
+      whereArgs: [now.subtract(maxAge).millisecondsSinceEpoch],
       limit: 100,
     );
 

--- a/lib/src/cache_store.dart
+++ b/lib/src/cache_store.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_cache_manager/src/cache_object.dart';
 import 'package:flutter_cache_manager/src/file_info.dart';
 import 'package:path/path.dart' as p;
@@ -11,6 +12,9 @@ import 'package:sqflite/sqflite.dart';
 ///Released under MIT License.
 
 class CacheStore {
+  @visibleForTesting
+  static Duration cleanupRunMinInterval = Duration(seconds: 10);
+
   Map<String, Future<CacheObject>> _futureCache = new Map();
   Map<String, CacheObject> _memCache = new Map();
 
@@ -24,7 +28,6 @@ class CacheStore {
   final Duration _maxAge;
 
   DateTime lastCleanupRun = DateTime.now();
-  static const Duration cleanupRunMinInterval = Duration(seconds: 10);
   Timer _scheduledCleanup;
 
   CacheStore(

--- a/lib/src/cache_store.dart
+++ b/lib/src/cache_store.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter_cache_manager/src/cache_object.dart';
 import 'package:flutter_cache_manager/src/file_info.dart';
 import 'package:path/path.dart' as p;
@@ -12,9 +11,6 @@ import 'package:sqflite/sqflite.dart';
 ///Released under MIT License.
 
 class CacheStore {
-  @visibleForTesting
-  static Duration cleanupRunMinInterval = Duration(seconds: 10);
-
   Map<String, Future<CacheObject>> _futureCache = new Map();
   Map<String, CacheObject> _memCache = new Map();
 
@@ -28,6 +24,7 @@ class CacheStore {
   final Duration _maxAge;
 
   DateTime lastCleanupRun = DateTime.now();
+  static const Duration cleanupRunMinInterval = Duration(seconds: 10);
   Timer _scheduledCleanup;
 
   CacheStore(

--- a/lib/src/cache_store.dart
+++ b/lib/src/cache_store.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_cache_manager/src/cache_object.dart';
 import 'package:flutter_cache_manager/src/file_info.dart';
 import 'package:path/path.dart' as p;
@@ -24,7 +25,7 @@ class CacheStore {
   final Duration _maxAge;
 
   DateTime lastCleanupRun = DateTime.now();
-  static const Duration cleanupRunMinInterval = Duration(seconds: 10);
+  Duration cleanupRunMinInterval = const Duration(seconds: 10);
   Timer _scheduledCleanup;
 
   CacheStore(
@@ -32,10 +33,11 @@ class CacheStore {
     filePath = basePath;
     basePath.then((p) => _filePath = p);
 
-    _cacheObjectProvider = _getObjectProvider();
+    _cacheObjectProvider = getObjectProvider();
   }
 
-  Future<CacheObjectProvider> _getObjectProvider() async {
+  @protected
+  Future<CacheObjectProvider> getObjectProvider() async {
     var databasesPath = await getDatabasesPath();
     var path = p.join(databasesPath, "$storeKey.db");
 


### PR DESCRIPTION
The main changes are:

* Mockable `cleanupRunMinInterval`, which allows us to test without waiting 10 seconds for the clean-up to happen.
* Mockable `CacheObjectProvider`, which opens up a large range of testing possibilities.

I also extracted the usages of `DateTime.now()` on `CacheObjectProvider` into a getter, so it's possible to run tests related to `CacheObjectProvider.getObjectsOverCapacity()`.