### PR TITLE
Upgrade FileFetcher to a FileService

### DIFF
--- a/lib/src/cache_manager.dart
+++ b/lib/src/cache_manager.dart
@@ -56,11 +56,11 @@ abstract class BaseCacheManager {
     this._cacheKey, {
     Duration maxAgeCacheObject = const Duration(days: 30),
     int maxNrOfCacheObjects = 200,
-    FileFetcher fileFetcher,
+    FileService fileService,
   }) {
     _store =
         CacheStore(_fileDir, _cacheKey, maxNrOfCacheObjects, maxAgeCacheObject);
-    _webHelper = WebHelper(_store, fileFetcher);
+    _webHelper = WebHelper(_store, fileService);
   }
 
   final String _cacheKey;

--- a/lib/src/file_fetcher.dart
+++ b/lib/src/file_fetcher.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'package:clock/clock.dart';
+import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 
 ///Flutter Cache Manager
@@ -10,11 +12,14 @@ abstract class FileService {
 }
 
 class HttpFileFetcher implements FileService {
-  final http.Client _httpClient = http.Client();
+  http.Client _httpClient;
+  HttpFileFetcher({http.Client httpClient}){
+    _httpClient = httpClient ?? http.Client();
+  }
 
   @override
   Future<FileFetcherResponse> get(String url,
-      {Map<String, String> headers}) async {
+      {Map<String, String> headers = const {}}) async {
     final req = http.Request('GET', Uri.parse(url));
     req.headers.addAll(headers);
     final httpResponse = await _httpClient.send(req);
@@ -34,7 +39,7 @@ abstract class FileFetcherResponse {
 class HttpFileFetcherResponse implements FileFetcherResponse {
   HttpFileFetcherResponse(this._response);
 
-  final DateTime _receivedTime = DateTime.now();
+  final DateTime _receivedTime = clock.now();
 
   final http.StreamedResponse _response;
 

--- a/lib/src/file_fetcher.dart
+++ b/lib/src/file_fetcher.dart
@@ -1,16 +1,22 @@
 import 'dart:async';
 import 'package:clock/clock.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter_cache_manager/src/web_helper.dart';
 import 'package:http/http.dart' as http;
 
 ///Flutter Cache Manager
 ///Copyright (c) 2019 Rene Floor
 ///Released under MIT License.
 
+/// Defines the interface for a file service.
+/// Most common file service will be an [HttpFileFetcher], however one can
+/// also make something more specialized. For example you could fetch files
+/// from other apps or from local storage.
 abstract class FileService {
   Future<FileFetcherResponse> get(String url, {Map<String, String> headers});
 }
 
+/// [HttpFileFetcher] is the most common file service and the default for
+/// [WebHelper]. One can easily adapt it to use dio or any other http client.
 class HttpFileFetcher implements FileService {
   http.Client _httpClient;
   HttpFileFetcher({http.Client httpClient}){
@@ -28,14 +34,21 @@ class HttpFileFetcher implements FileService {
   }
 }
 
+/// Defines the interface for a get result of a [FileService].
 abstract class FileFetcherResponse {
+  /// [content] is a stream of bytes
   Stream<List<int>> get content => null;
+  /// [statusCode] is expected to conform to an http status code.
   int get statusCode;
+  /// Defines till when the cache should be assumed to be valid.
   DateTime get validTill;
+  /// [eTag] is used when asking to update the cache
   String get eTag;
+  /// Used to save the file on the storage, includes a dot. For example '.jpeg'
   String get fileExtension;
 }
 
+/// Basic implementation of a [FileFetcherResponse] for http requests.
 class HttpFileFetcherResponse implements FileFetcherResponse {
   HttpFileFetcherResponse(this._response);
 

--- a/lib/src/file_fetcher.dart
+++ b/lib/src/file_fetcher.dart
@@ -1,42 +1,92 @@
 import 'dart:async';
-import 'dart:typed_data';
-
 import 'package:http/http.dart' as http;
 
 ///Flutter Cache Manager
 ///Copyright (c) 2019 Rene Floor
 ///Released under MIT License.
 
-typedef Future<FileFetcherResponse> FileFetcher(String url, {Map<String, String> headers});
+abstract class FileService {
+  Future<FileFetcherResponse> get(String url, {Map<String, String> headers});
+}
+
+class HttpFileFetcher implements FileService {
+  final http.Client _httpClient = http.Client();
+
+  @override
+  Future<FileFetcherResponse> get(String url,
+      {Map<String, String> headers}) async {
+    final req = http.Request('GET', Uri.parse(url));
+    req.headers.addAll(headers);
+    final httpResponse = await _httpClient.send(req);
+
+    return HttpFileFetcherResponse(httpResponse);
+  }
+}
 
 abstract class FileFetcherResponse {
+  Stream<List<int>> get content => null;
   int get statusCode;
-
-  bool hasHeader(String name);
-
-  String header(String name);
-
-  Uint8List get bodyBytes => null;
+  DateTime get validTill;
+  String get eTag;
+  String get fileExtension;
 }
 
 class HttpFileFetcherResponse implements FileFetcherResponse {
-  const HttpFileFetcherResponse(this._response);
+  HttpFileFetcherResponse(this._response);
 
-  final http.Response _response;
+  final DateTime _receivedTime = DateTime.now();
+
+  final http.StreamedResponse _response;
 
   @override
   int get statusCode => _response.statusCode;
 
-  @override
-  bool hasHeader(String name) {
+  bool _hasHeader(String name) {
     return _response.headers.containsKey(name);
   }
 
-  @override
-  String header(String name) {
+  String _header(String name) {
     return _response.headers[name];
   }
 
   @override
-  Uint8List get bodyBytes => _response.bodyBytes;
+  Stream<List<int>> get content => _response.stream;
+
+  @override
+  DateTime get validTill {
+    // Without a cache-control header we keep the file for a week
+    var ageDuration = const Duration(days: 7);
+    if (_hasHeader('cache-control')) {
+      final controlSettings = _header('cache-control').split(',');
+      for (final setting in controlSettings) {
+        final sanitizedSetting = setting.trim().toLowerCase();
+        if (sanitizedSetting == 'no-cache') {
+          ageDuration = const Duration();
+        }
+        if (sanitizedSetting.startsWith('max-age=')) {
+          var validSeconds = int.tryParse(sanitizedSetting.split('=')[1]) ?? 0;
+          if (validSeconds > 0) {
+            ageDuration = Duration(seconds: validSeconds);
+          }
+        }
+      }
+    }
+
+    return _receivedTime.add(ageDuration);
+  }
+
+  @override
+  String get eTag => _hasHeader('etag') ? _header('etag') : null;
+
+  @override
+  String get fileExtension {
+    var fileExtension = '';
+    if (_hasHeader('content-type')) {
+      final type = _header('content-type').split('/');
+      if (type.length == 2) {
+        fileExtension = '.${type[1]}';
+      }
+    }
+    return fileExtension;
+  }
 }

--- a/lib/src/web_helper.dart
+++ b/lib/src/web_helper.dart
@@ -1,13 +1,10 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:file/file.dart' as f;
 import 'package:flutter_cache_manager/src/storage/cache_object.dart';
 import 'package:flutter_cache_manager/src/cache_store.dart';
 import 'package:flutter_cache_manager/src/file_fetcher.dart';
 import 'package:flutter_cache_manager/src/file_info.dart';
-import 'package:http/http.dart' as http;
-import 'package:path/path.dart' as p;
 import 'package:pedantic/pedantic.dart';
 import 'package:uuid/uuid.dart';
 

--- a/lib/src/web_helper.dart
+++ b/lib/src/web_helper.dart
@@ -16,21 +16,23 @@ import 'package:uuid/uuid.dart';
 ///Released under MIT License.
 
 class WebHelper {
-  WebHelper(this._store, FileFetcher fileFetcher)
+  WebHelper(this._store, FileService fileFetcher)
       : _memCache = {},
-        _fileFetcher = fileFetcher ?? _defaultHttpGetter;
+        _fileFetcher = fileFetcher ?? HttpFileFetcher();
 
   final CacheStore _store;
-  final FileFetcher _fileFetcher;
+  final FileService _fileFetcher;
   final Map<String, Future<FileInfo>> _memCache;
 
   ///Download the file from the url
-  Future<FileInfo> downloadFile(String url, {Map<String, String> authHeaders, bool ignoreMemCache = false}) async {
+  Future<FileInfo> downloadFile(String url,
+      {Map<String, String> authHeaders, bool ignoreMemCache = false}) async {
     if (!_memCache.containsKey(url) || ignoreMemCache) {
       var completer = Completer<FileInfo>();
       unawaited(() async {
         try {
-          final cacheObject = await _downloadRemoteFile(url, authHeaders: authHeaders);
+          final cacheObject =
+              await _downloadRemoteFile(url, authHeaders: authHeaders);
           completer.complete(cacheObject);
         } catch (e) {
           completer.completeError(e);
@@ -44,7 +46,8 @@ class WebHelper {
   }
 
   ///Download the file from the url
-  Future<FileInfo> _downloadRemoteFile(String url, {Map<String, String> authHeaders}) async {
+  Future<FileInfo> _downloadRemoteFile(String url,
+      {Map<String, String> authHeaders}) async {
     var cacheObject = await _store.retrieveCacheData(url);
     cacheObject ??= CacheObject(url);
 
@@ -57,7 +60,7 @@ class WebHelper {
       headers['If-None-Match'] = cacheObject.eTag;
     }
 
-    final response = await _fileFetcher(url, headers: headers);
+    final response = await _fileFetcher.get(url, headers: headers);
     final success = await _handleHttpResponse(response, cacheObject);
     if (!success) {
       throw HttpExceptionWithStatus(
@@ -73,12 +76,8 @@ class WebHelper {
     return FileInfo(file, FileSource.Online, cacheObject.validTill, url);
   }
 
-  static Future<FileFetcherResponse> _defaultHttpGetter(String url, {Map<String, String> headers}) async {
-    final httpResponse = await http.get(url, headers: headers);
-    return HttpFileFetcherResponse(httpResponse);
-  }
-
-  Future<bool> _handleHttpResponse(FileFetcherResponse response, CacheObject cacheObject) async {
+  Future<bool> _handleHttpResponse(
+      FileFetcherResponse response, CacheObject cacheObject) async {
     if (response.statusCode == 200 || response.statusCode == 201) {
       final basePath = await _store.fileDir;
       unawaited(_setDataFromHeaders(cacheObject, response));
@@ -87,7 +86,11 @@ class WebHelper {
       if (!(await folder.exists())) {
         folder.createSync(recursive: true);
       }
-      await file.writeAsBytes(response.bodyBytes);
+
+      final sink = file.openWrite();
+      await sink.addStream(response.content);
+      await sink.close();
+
       return true;
     }
     if (response.statusCode == 304) {
@@ -97,38 +100,11 @@ class WebHelper {
     return false;
   }
 
-  Future<void> _setDataFromHeaders(CacheObject cacheObject, FileFetcherResponse response) async {
-    // Without a cache-control header we keep the file for a week
-    var ageDuration = const Duration(days: 7);
-    if (response.hasHeader('cache-control')) {
-      final controlSettings = response.header('cache-control').split(',');
-      for (final setting in controlSettings) {
-        final sanitizedSetting = setting.trim().toLowerCase();
-        if (sanitizedSetting == 'no-cache') {
-          ageDuration = const Duration();
-        }
-        if (sanitizedSetting.startsWith('max-age=')) {
-          var validSeconds = int.tryParse(sanitizedSetting.split('=')[1]) ?? 0;
-          if (validSeconds > 0) {
-            ageDuration = Duration(seconds: validSeconds);
-          }
-        }
-      }
-    }
-
-    cacheObject.validTill = DateTime.now().add(ageDuration);
-
-    if (response.hasHeader('etag')) {
-      cacheObject.eTag = response.header('etag');
-    }
-
-    var fileExtension = '';
-    if (response.hasHeader('content-type')) {
-      final type = response.header('content-type').split('/');
-      if (type.length == 2) {
-        fileExtension = '.${type[1]}';
-      }
-    }
+  Future<void> _setDataFromHeaders(
+      CacheObject cacheObject, FileFetcherResponse response) async {
+    cacheObject.validTill = response.validTill;
+    cacheObject.eTag = response.eTag;
+    final fileExtension = response.fileExtension;
 
     final oldPath = cacheObject.relativePath;
     if (oldPath != null && !oldPath.endsWith(fileExtension)) {
@@ -148,6 +124,7 @@ class WebHelper {
 }
 
 class HttpExceptionWithStatus extends HttpException {
-  const HttpExceptionWithStatus(this.statusCode, String message, {Uri uri}) : super(message, uri: uri);
+  const HttpExceptionWithStatus(this.statusCode, String message, {Uri uri})
+      : super(message, uri: uri);
   final int statusCode;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   path: "^1.6.4"
   sqflite: "^1.1.7+2"
   pedantic: "^1.8.0+1"
+  clock: ^1.0.1
   file: ^5.1.0
 
 dev_dependencies:

--- a/test/cache_object_test.dart
+++ b/test/cache_object_test.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:flutter_cache_manager/src/storage/cache_object.dart';
 import 'package:flutter_cache_manager/src/storage/cache_object_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;

--- a/test/http_file_fetcher_tests.dart
+++ b/test/http_file_fetcher_tests.dart
@@ -1,4 +1,3 @@
-import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:clock/clock.dart';

--- a/test/http_file_fetcher_tests.dart
+++ b/test/http_file_fetcher_tests.dart
@@ -1,0 +1,38 @@
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:clock/clock.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart';
+import 'package:http/testing.dart';
+
+void main() {
+  group('Check header values', () {
+    test('Valid headers should be parsed normally', () async {
+      var eTag = 'test';
+      var fileExtension = 'jpeg';
+      var contentType = 'image/$fileExtension';
+      var maxAge = const Duration(hours: 2);
+
+      var client = MockClient((request) async {
+        return Response.bytes(Uint8List(16), 200,
+            headers: {
+              'etag': 'test',
+              'content-type': contentType,
+              'cache-control': 'max-age=${maxAge.inSeconds}'
+        });
+      });
+
+      await withClock(Clock.fixed(DateTime.now()),() async {
+        var httpFileFetcher = HttpFileFetcher(httpClient: client);
+        final now = clock.now();
+        final response = await httpFileFetcher.get('test.com/image');
+
+        expect(response.eTag, eTag);
+        expect(response.fileExtension, '.$fileExtension');
+        expect(response.validTill, now.add(maxAge));
+      });
+    });
+  });
+}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Changing the FileFetcher from a function to an interface gives the option to extend this further on. For example you could think of a post function to post a file to a server when adding it to the cache. 
It also makes it easier to create a Mock FileFetcher.

Adding all needed info as properties of the FileFetcherResponse ensures that the writer of a FileFetcherResponse knows which info is expected and used. Also it makes it easier to manipulate the logic around the headers.

### :arrow_heading_down: What is the current behavior?
The FileFetcher is just a function and the WebHelper digs into the headers while it shouldn't even have to know how the headers are named.

### :new: What is the new behavior (if this is a feature change)?
Behavior is kept stable.

### :boom: Does this PR introduce a breaking change?
Yep! Users of this library that added their own FileFetcher wil have to rewrite it. Most breaking change is the use of a stream instead of plain bytes, but users of Dio should be able to easily implement it. (Perhaps good idea to add a DioFileFetcher at least for reference.)

### :bug: Recommendations for testing
Test downloading files.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
