### PR TITLE
add contentLength in FileFetcherResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [2.0.0] - WIP
+* [BREAKING CHANGE] Changes to FileFetcher and FileFetcherResponse:
+    * FileFetcher is now a FileService and a class instead of a function.
+    * FileFetcherResponse doesn't just give magic headers, but concrete implementation of the needed information.
+    * FileFetcherResponse gives a contentStream instead of content for more efficient handling of the data.
+    * FileFetcherResponse contains contentLength with information about the total size of the content.
+* Changes in CacheStore for testability:
+    * CleanupRunMinInterval can now be set.
+    * Expects a mockable directory instead of a path.
+* Added CacheInfoRepository interface to possibly replace the current CacheObjectProvider based on sqflite.
+
 ## [1.1.3] - 2019-10-17
 * Use try-catch in WebHelper so VM understands that errors are not uncaught.
 

--- a/lib/src/web/file_fetcher.dart
+++ b/lib/src/web/file_fetcher.dart
@@ -40,6 +40,10 @@ abstract class FileFetcherResponse {
   /// [content] is a stream of bytes
   Stream<List<int>> get content;
 
+  /// [contentLength] is the total size of the content.
+  /// If the size is not known beforehand contentLength is null.
+  int get contentLength;
+
   /// [statusCode] is expected to conform to an http status code.
   int get statusCode;
 
@@ -74,6 +78,9 @@ class HttpFileFetcherResponse implements FileFetcherResponse {
 
   @override
   Stream<List<int>> get content => _response.stream;
+
+  @override
+  int get contentLength => _response.contentLength;
 
   @override
   DateTime get validTill {

--- a/test/http_file_fetcher_test.dart
+++ b/test/http_file_fetcher_test.dart
@@ -12,10 +12,11 @@ void main() {
       var eTag = 'test';
       var fileExtension = 'jpg';
       var contentType = 'image/jpeg';
+      var contentLength = 16;
       var maxAge = const Duration(hours: 2);
 
       var client = MockClient((request) async {
-        return Response.bytes(Uint8List(16), 200,
+        return Response.bytes(Uint8List(contentLength), 200,
             headers: {
               'etag': 'test',
               'content-type': contentType,
@@ -28,6 +29,7 @@ void main() {
         final now = clock.now();
         final response = await httpFileFetcher.get('test.com/image');
 
+        expect(response.contentLength, contentLength);
         expect(response.eTag, eTag);
         expect(response.fileExtension, '.$fileExtension');
         expect(response.validTill, now.add(maxAge));

--- a/test/web_helper_test.dart
+++ b/test/web_helper_test.dart
@@ -22,6 +22,7 @@ void main() {
           .thenAnswer((_) {
         return Future.value(MockFileFetcherResponse(
             Stream.value([0, 1, 2, 3, 4, 5]),
+            0,
             'testv1',
             '.jpg',
             200,
@@ -46,7 +47,7 @@ void main() {
       when(fileService.get(imageUrl, headers: anyNamed('headers')))
           .thenAnswer((_) {
         return Future.value(MockFileFetcherResponse(
-            null, 'testv1', '.jpg', 200, DateTime.now()));
+            null, 0, 'testv1', '.jpg', 200, DateTime.now()));
       });
 
       var webHelper = WebHelper(store, fileService);
@@ -66,7 +67,7 @@ void main() {
       when(fileService.get(imageUrl, headers: anyNamed('headers')))
           .thenAnswer((_) {
         return Future.value(
-            MockFileFetcherResponse(null, null, '', 404, DateTime.now()));
+            MockFileFetcherResponse(null, 0, null, '', 404, DateTime.now()));
       });
 
       var webHelper = WebHelper(store, fileService);
@@ -90,7 +91,7 @@ void main() {
       when(fileService.get(imageUrl, headers: anyNamed('headers')))
           .thenAnswer((_) {
         return Future.value(MockFileFetcherResponse(
-            null, 'testv1', '.jpg', 304, DateTime.now()));
+            null, 0, 'testv1', '.jpg', 304, DateTime.now()));
       });
 
       var webHelper = WebHelper(store, fileService);
@@ -113,7 +114,7 @@ void main() {
       when(fileService.get(imageUrl, headers: anyNamed('headers')))
           .thenAnswer((_) {
         return Future.value(MockFileFetcherResponse(
-            Stream.value([0, 1, 2, 3, 4, 5]),
+            Stream.value([0, 1, 2, 3, 4, 5]), 6,
             'testv1',
             '.jpg',
             200,
@@ -141,7 +142,7 @@ void main() {
       when(fileService.get(imageUrl, headers: anyNamed('headers')))
           .thenAnswer((_) {
         return Future.value(MockFileFetcherResponse(
-            Stream.value([0, 1, 2, 3, 4, 5]),
+            Stream.value([0, 1, 2, 3, 4, 5]), 6,
             'testv1',
             '.jpg',
             200,
@@ -164,12 +165,13 @@ class MockFileService extends Mock implements FileService {}
 
 class MockFileFetcherResponse implements FileFetcherResponse {
   final Stream<List<int>> _content;
+  final int _contentLength;
   final String _eTag;
   final String _fileExtension;
   final int _statusCode;
   final DateTime _validTill;
 
-  MockFileFetcherResponse(this._content, this._eTag, this._fileExtension,
+  MockFileFetcherResponse(this._content, this._contentLength, this._eTag, this._fileExtension,
       this._statusCode, this._validTill);
 
   @override
@@ -190,4 +192,8 @@ class MockFileFetcherResponse implements FileFetcherResponse {
   @override
   // TODO: implement validTill
   DateTime get validTill => _validTill;
+
+  @override
+  // TODO: implement contentLength
+  int get contentLength => _contentLength;
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Add contentLength to FileFetcherResponse so we can add progress later

### :arrow_heading_down: What is the current behavior?
Not available

### :new: What is the new behavior (if this is a feature change)?
Make it available

### :boom: Does this PR introduce a breaking change?
Yes, all FileFetcherResponses should add a contentLength field

### :bug: Recommendations for testing
-

### :memo: Links to relevant issues/docs
-

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
