### PR TITLE
Change "to big" to "too big" in the BaseCacheManager constructor docs

### DIFF
--- a/lib/src/cache_manager.dart
+++ b/lib/src/cache_manager.dart
@@ -49,7 +49,7 @@ abstract class BaseCacheManager {
   ///
   /// The [_cacheKey] is used for the sqlite database file and should be unique.
   /// Files are removed when they haven't been used for longer than [_maxAgeCacheObject]
-  /// or when this cache has grown to big. When the cache is larger than [_maxNrOfCacheObjects]
+  /// or when this cache has grown too big. When the cache is larger than [_maxNrOfCacheObjects]
   /// files the files that haven't been used longest will be removed.
   /// The [httpGetter] can be used to customize how files are downloaded. For example
   /// to edit the urls, add headers or use a proxy.


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Docs update (fixes a grammatical error)

### :boom: Does this PR introduce a breaking change?
I hope not, that would be a pretty weird compiler bug

### :memo: Links to relevant issues/docs
https://www.grammarly.com/blog/to-too/

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
