### PR TITLE
Don't compare with full content-type, but with mimetype

### DIFF
--- a/lib/src/web/mime_converter.dart
+++ b/lib/src/web/mime_converter.dart
@@ -4,7 +4,7 @@ import 'dart:io';
 extension ContentTypeConverter on ContentType {
   String get fileExtension {
     if (this == null) return null;
-    if (mimeTypes.containsKey(toString())) return mimeTypes[toString()];
+    if (mimeTypes.containsKey(mimeType)) return mimeTypes[mimeType];
     return '.$subType';
   }
 }

--- a/test/http_file_fetcher_test.dart
+++ b/test/http_file_fetcher_test.dart
@@ -52,6 +52,21 @@ void main() {
       expect(response.fileExtension, '.$fileExtension');
     });
 
+    test('Content-Type parameters should be ignored', () async {
+      var fileExtension = 'mp3';
+      var contentType = 'audio/mpeg;chartset=UTF-8';
+
+      var client = MockClient((request) async {
+        return Response.bytes(Uint8List(16), 200,
+            headers: {'content-type': contentType});
+      });
+
+      var httpFileFetcher = HttpFileService(httpClient: client);
+      final response = await httpFileFetcher.get('test.com/document');
+
+      expect(response.fileExtension, '.$fileExtension');
+    });
+
     test('Test CompatFileService', () async {
       var eTag = 'test';
       var fileExtension = 'jpg';


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes #164
Only looks at mimeType part of content-type.

### :arrow_heading_down: What is the current behavior?
Compares full content-type, which means anything with optional parameters, such as application/pdf;chartset=UTF-8 could fail

### :boom: Does this PR introduce a breaking change?
Not really

### :bug: Recommendations for testing
Tests are added

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
