### PR TITLE
Add support for RxDart 0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.2.2] - 2020-04-16
+* Support for RxDart 0.24.x
+
 ## [1.2.1] - 2020-04-14
 * Fixed optional parameters in the Content-Type header ([#164](https://github.com/Baseflow/flutter_cache_manager/issues/164)).
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -14,7 +14,7 @@ class MyApp extends StatelessWidget {
 }
 
 const url =
-    'https://cdn2.online-convert.com/example-file/raster%20image/png/example.png';
+    'https://file-examples.com/wp-content/uploads/2018/04/file_example_AVI_1280_1_5MG.avi';
 
 class MyHomePage extends StatefulWidget {
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_cache_manager
 description: Generic cache manager for flutter. Saves web files on the storages of the device and saves the cache info using sqflite.
-version: 1.2.1
+version: 1.2.2
 homepage: https://github.com/Baseflow/flutter_cache_manager
 
 environment:
@@ -17,7 +17,7 @@ dependencies:
   pedantic: "^1.8.0+1"
   clock: ^1.0.1
   file: ^5.1.0
-  rxdart: ^0.23.1
+  rxdart: '>=0.23.1 <0.25.0'
 
 dev_dependencies:
   flutter_test:

--- a/test/cache_object_test.dart
+++ b/test/cache_object_test.dart
@@ -32,26 +32,24 @@ void main() {
       expect(object.validTill, validDate);
     });
 
-    test('Test encoding CacheObject to map', ()
-    async {
-      await withClock(Clock.fixed(now), ()
-        async {
-          var object = CacheObject(
-            'baseflow.com/test.png',
-            relativePath: 'test.png',
-            validTill: validDate,
-            eTag: 'test1',
-            id: 3,
-          );
+    test('Test encoding CacheObject to map', () async {
+      await withClock(Clock.fixed(now), () async {
+        var object = CacheObject(
+          'baseflow.com/test.png',
+          relativePath: 'test.png',
+          validTill: validDate,
+          eTag: 'test1',
+          id: 3,
+        );
 
-          var map = object.toMap();
-          expect(map[columnId], 3);
-          expect(map[columnUrl], 'baseflow.com/test.png');
-          expect(map[columnPath], 'test.png');
-          expect(map[columnETag], 'test1');
-          expect(map[columnValidTill], validMillis);
-          expect(map[columnTouched], now.millisecondsSinceEpoch);
-        });
+        var map = object.toMap();
+        expect(map[columnId], 3);
+        expect(map[columnUrl], 'baseflow.com/test.png');
+        expect(map[columnPath], 'test.png');
+        expect(map[columnETag], 'test1');
+        expect(map[columnValidTill], validMillis);
+        expect(map[columnTouched], now.millisecondsSinceEpoch);
       });
+    });
   });
 }

--- a/test/cache_store_test.dart
+++ b/test/cache_store_test.dart
@@ -72,7 +72,8 @@ void main() {
       expect(await store.retrieveCacheData('baseflow.com/test.png'), isNotNull);
     });
 
-    test('Store should return CacheInfo from memory when asked twice', () async {
+    test('Store should return CacheInfo from memory when asked twice',
+        () async {
       var repo = MockRepo();
 
       var tempDir = createDir();
@@ -83,12 +84,11 @@ void main() {
 
       var store = CacheStore(tempDir, 'test', 30, const Duration(days: 7),
           cacheRepoProvider: Future.value(repo));
-      
+
       var result = await store.retrieveCacheData('baseflow.com/test.png');
       expect(result, isNotNull);
-      var _  = await store.retrieveCacheData('baseflow.com/test.png');
+      var _ = await store.retrieveCacheData('baseflow.com/test.png');
       verify(repo.get(any)).called(1);
-      
     });
 
     test(
@@ -111,7 +111,7 @@ void main() {
     });
   });
 
-  group('Storing files in store', (){
+  group('Storing files in store', () {
     test('Store should store fileinfo in repo', () async {
       var repo = MockRepo();
 
@@ -120,16 +120,15 @@ void main() {
       var store = CacheStore(tempDir, 'test', 30, const Duration(days: 7),
           cacheRepoProvider: Future.value(repo));
 
-
-      var cacheObject = CacheObject('baseflow.com/test.png', relativePath: 'testimage.png');
+      var cacheObject =
+          CacheObject('baseflow.com/test.png', relativePath: 'testimage.png');
       await store.putFile(cacheObject);
 
       verify(repo.updateOrInsert(cacheObject)).called(1);
     });
   });
 
-
-  group('Removing files in store', (){
+  group('Removing files in store', () {
     test('Store should remove fileinfo from repo on delete', () async {
       var repo = MockRepo();
 
@@ -138,7 +137,8 @@ void main() {
       var store = CacheStore(tempDir, 'test', 30, const Duration(days: 7),
           cacheRepoProvider: Future.value(repo));
 
-      var cacheObject = CacheObject('baseflow.com/test.png', relativePath: 'testimage.png', id: 1);
+      var cacheObject = CacheObject('baseflow.com/test.png',
+          relativePath: 'testimage.png', id: 1);
       await store.removeCachedFile(cacheObject);
 
       verify(repo.deleteAll(argThat(contains(cacheObject.id)))).called(1);
@@ -152,12 +152,15 @@ void main() {
           cacheRepoProvider: Future.value(repo),
           cleanupRunMinInterval: const Duration());
 
-      var cacheObject = CacheObject('baseflow.com/test.png', relativePath: 'testimage.png', id: 1);
+      var cacheObject = CacheObject('baseflow.com/test.png',
+          relativePath: 'testimage.png', id: 1);
       await (await directory).childFile('testimage.png').create();
 
-      when(repo.getObjectsOverCapacity(any)).thenAnswer((_) => Future.value([cacheObject]));
+      when(repo.getObjectsOverCapacity(any))
+          .thenAnswer((_) => Future.value([cacheObject]));
       when(repo.getOldObjects(any)).thenAnswer((_) => Future.value([]));
-      when(repo.get('baseflow.com/test.png')).thenAnswer((_) => Future.value(cacheObject));
+      when(repo.get('baseflow.com/test.png'))
+          .thenAnswer((_) => Future.value(cacheObject));
 
       expect(await store.getFile('baseflow.com/test.png'), isNotNull);
 
@@ -175,12 +178,16 @@ void main() {
           cacheRepoProvider: Future.value(repo),
           cleanupRunMinInterval: const Duration());
 
-      var cacheObject = CacheObject('baseflow.com/test.png', relativePath: 'testimage.png', id: 1);
+      var cacheObject = CacheObject('baseflow.com/test.png',
+          relativePath: 'testimage.png', id: 1);
       await (await directory).childFile('testimage.png').create();
 
-      when(repo.getObjectsOverCapacity(any)).thenAnswer((_) => Future.value([]));
-      when(repo.getOldObjects(any)).thenAnswer((_) => Future.value([cacheObject]));
-      when(repo.get('baseflow.com/test.png')).thenAnswer((_) => Future.value(cacheObject));
+      when(repo.getObjectsOverCapacity(any))
+          .thenAnswer((_) => Future.value([]));
+      when(repo.getOldObjects(any))
+          .thenAnswer((_) => Future.value([cacheObject]));
+      when(repo.get('baseflow.com/test.png'))
+          .thenAnswer((_) => Future.value(cacheObject));
 
       expect(await store.getFile('baseflow.com/test.png'), isNotNull);
 
@@ -190,7 +197,8 @@ void main() {
       verify(repo.deleteAll(argThat(contains(cacheObject.id)))).called(1);
     });
 
-    test('Store should not remove files that are not old or over capacity', () async {
+    test('Store should not remove files that are not old or over capacity',
+        () async {
       var repo = MockRepo();
       var directory = createDir();
 
@@ -198,12 +206,15 @@ void main() {
           cacheRepoProvider: Future.value(repo),
           cleanupRunMinInterval: const Duration());
 
-      var cacheObject = CacheObject('baseflow.com/test.png', relativePath: 'testimage.png', id: 1);
+      var cacheObject = CacheObject('baseflow.com/test.png',
+          relativePath: 'testimage.png', id: 1);
       await (await directory).childFile('testimage.png').create();
 
-      when(repo.getObjectsOverCapacity(any)).thenAnswer((_) => Future.value([]));
+      when(repo.getObjectsOverCapacity(any))
+          .thenAnswer((_) => Future.value([]));
       when(repo.getOldObjects(any)).thenAnswer((_) => Future.value([]));
-      when(repo.get('baseflow.com/test.png')).thenAnswer((_) => Future.value(cacheObject));
+      when(repo.get('baseflow.com/test.png'))
+          .thenAnswer((_) => Future.value(cacheObject));
 
       expect(await store.getFile('baseflow.com/test.png'), isNotNull);
 
@@ -213,7 +224,6 @@ void main() {
       verifyNever(repo.deleteAll(argThat(contains(cacheObject.id))));
     });
 
-
     test('Store should remove all files when emptying cache', () async {
       var repo = MockRepo();
       var directory = createDir();
@@ -222,15 +232,20 @@ void main() {
           cacheRepoProvider: Future.value(repo),
           cleanupRunMinInterval: const Duration());
 
-      var co1 = CacheObject('baseflow.com/test.png', relativePath: 'testimage1.png', id: 1);
-      var co2 = CacheObject('baseflow.com/test.png', relativePath: 'testimage2.png', id: 2);
-      var co3 = CacheObject('baseflow.com/test.png', relativePath: 'testimage3.png', id: 3);
+      var co1 = CacheObject('baseflow.com/test.png',
+          relativePath: 'testimage1.png', id: 1);
+      var co2 = CacheObject('baseflow.com/test.png',
+          relativePath: 'testimage2.png', id: 2);
+      var co3 = CacheObject('baseflow.com/test.png',
+          relativePath: 'testimage3.png', id: 3);
 
-      when(repo.getAllObjects()).thenAnswer((_) => Future.value([co1, co2, co3]));
+      when(repo.getAllObjects())
+          .thenAnswer((_) => Future.value([co1, co2, co3]));
 
       await store.emptyCache();
 
-      verify(repo.deleteAll(argThat(containsAll([co1.id, co2.id, co3.id])))).called(1);
+      verify(repo.deleteAll(argThat(containsAll([co1.id, co2.id, co3.id]))))
+          .called(1);
     });
   });
 }

--- a/test/web_helper_test.dart
+++ b/test/web_helper_test.dart
@@ -89,7 +89,9 @@ void main() {
       });
 
       var webHelper = WebHelper(store, fileService);
-      var result = await webHelper.downloadFile(imageUrl).firstWhere((r) => r is FileInfo, orElse: null);
+      var result = await webHelper
+          .downloadFile(imageUrl)
+          .firstWhere((r) => r is FileInfo, orElse: null);
       expect(result, isNotNull);
     });
   });
@@ -173,7 +175,9 @@ void main() {
       });
 
       var webHelper = WebHelper(store, fileService);
-      var result = await webHelper.downloadFile(imageUrl).firstWhere((r) => r is FileInfo, orElse: null);
+      var result = await webHelper
+          .downloadFile(imageUrl)
+          .firstWhere((r) => r is FileInfo, orElse: null);
       expect(result, isNotNull);
       verify(store.putFile(any)).called(1);
     });
@@ -205,7 +209,9 @@ void main() {
       var webHelper = WebHelper(store, fileService);
 
       expect(await file.exists(), true);
-      var _ = await webHelper.downloadFile(imageUrl).firstWhere((r) => r is FileInfo, orElse: null);
+      var _ = await webHelper
+          .downloadFile(imageUrl)
+          .firstWhere((r) => r is FileInfo, orElse: null);
       expect(await file.exists(), false);
     });
   });


### PR DESCRIPTION
Fixes #166

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Add support for RxDart 0.24.

### :boom: Does this PR introduce a breaking change?
No, 0.23 is still supported

### :bug: Recommendations for testing
Tests still run

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
