### PR TITLE
Added Firebase Storage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,31 @@ class CustomCacheManager extends BaseCacheManager {
 }
 
 ```
+If the file is located on Firebase Storage it can be accessed by using the provided `FirebaseHttpFileService`.
+Wherever the url is provided now becomes a Firebase Storage path, e.g. `getFileStream(firebaseStoragePath)`.
+
+```
+
+class FirebaseCacheManager extends BaseCacheManager {
+  static const key = 'firebaseCache';
+
+  static FirebaseCacheManager _instance;
+
+  factory FirebaseCacheManager() {
+    _instance ??= FirebaseCacheManager._();
+    return _instance;
+  }
+
+  FirebaseCacheManager._() : super(key, fileService: FirebaseHttpFileService());
+
+  @override
+  Future<String> getFilePath() async {
+    var directory = await getTemporaryDirectory();
+    return p.join(directory.path, key);
+  }
+}
+
+```
 
 ## How it works
 By default the cached files are stored in the temporary directory of the app. This means the OS can delete the files any time.

--- a/lib/src/cache_manager.dart
+++ b/lib/src/cache_manager.dart
@@ -21,7 +21,6 @@ import 'package:uuid/uuid.dart';
 ///Flutter Cache Manager
 ///Copyright (c) 2019 Rene Floor
 ///Released under MIT License.
-
 /// The DefaultCacheManager that can be easily used directly. The code of
 /// this implementation can be used as inspiration for more complex cache
 /// managers.

--- a/lib/src/web/file_service.dart
+++ b/lib/src/web/file_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'package:clock/clock.dart';
 import 'package:http/http.dart' as http;
+import 'package:firebase_storage/firebase_storage.dart';
 import 'mime_converter.dart';
 
 ///Flutter Cache Manager
@@ -32,6 +33,20 @@ class HttpFileService implements FileService {
     final httpResponse = await _httpClient.send(req);
 
     return HttpGetResponse(httpResponse);
+  }
+}
+
+/// [FirebaseHttpFileService] is another common file service which parses a
+/// firebase reference into, to standard url which can be passed to the
+/// standard [HttpFileService].
+class FirebaseHttpFileService extends HttpFileService {
+  @override
+  Future<FileServiceResponse> get(String url,
+      {Map<String, String> headers = const {}}) async {
+    var ref = FirebaseStorage.instance.ref().child(url);
+    var _url = await ref.getDownloadURL() as String;
+
+    return super.get(_url);
   }
 }
 

--- a/lib/src/web/mime_converter.dart
+++ b/lib/src/web/mime_converter.dart
@@ -90,5 +90,4 @@ const mimeTypes = {
   'video/webm': '.webm',
   'video/x-msvideo': '.avi',
   'video/quicktime': '.mov'
-    
 };

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,8 @@ dependencies:
   clock: ^1.0.1
   file: ^5.1.0
   rxdart: '>=0.23.1 <0.25.0'
-
+  firebase_storage: ^3.0.3
+  
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This feature provides an alternative HttpFileService called FirebaseHttpFileService which can be passed to a custom cache manager to retrieve Firebase files out of the box.

### :arrow_heading_down: What is the current behavior?
Currently a custom file service has to be written to handle conversion from Firebase Storage path to URL.

### :new: What is the new behavior (if this is a feature change)?
Resolves Firebase Storage paths to downloadable URL links with a provided file service.

### :boom: Does this PR introduce a breaking change?
Not as far as I'm aware, any bad paths are handled by the _pushFileToStream method of WebHelper and return `CacheManager: Failed to download file from $url with error:\n$e`

### :bug: Recommendations for testing
Tests should be set up for this feature but this involves using an existing or creating a new Firebase instance with dummy data. Something to consider for the package developers. 

### :memo: Links to relevant issues/docs
[FirebaseStorage class] (https://pub.dev/documentation/firebase_storage/latest/firebase_storage/FirebaseStorage-class.html)

On flutter 1.17.1 the errorWidget causes: setState() called after dispose() see [issue here](https://github.com/Baseflow/flutter_cached_network_image/issues/396).

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
