### PR TITLE
allow reloading database entries in CacheStore

### DIFF
--- a/flutter_cache_manager/lib/src/cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_manager.dart
@@ -198,8 +198,11 @@ abstract class BaseCacheManager {
     return fileResponse as FileInfo;
   }
 
-  ///Get the file from the cache
-  Future<FileInfo> getFileFromCache(String url) => _store.getFile(url);
+  /// Get the file from the cache.
+  /// Specify [ignoreMemCache] to force a re-read from the database
+  Future<FileInfo> getFileFromCache(String url,
+          {bool ignoreMemCache = false}) =>
+      _store.getFile(url, ignoreMemCache: ignoreMemCache);
 
   ///Returns the file from memory if it has already been fetched
   FileInfo getFileFromMemory(String url) => _store.getFileFromMemory(url);

--- a/flutter_cache_manager/lib/src/cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_manager.dart
@@ -105,6 +105,9 @@ abstract class BaseCacheManager {
   /// WebHelper to download and store files
   WebHelper _webHelper;
 
+  /// Get the underlying web helper
+  WebHelper get webHelper => _webHelper;
+
   /// Get the file from the cache and/or online, depending on availability and age.
   /// Downloaded form [url], [headers] can be used for example for authentication.
   /// When a file is cached it is return directly, when it is too old the file is

--- a/flutter_cache_manager/lib/src/cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_manager.dart
@@ -7,14 +7,14 @@ import 'package:file/local.dart';
 import 'package:file/memory.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_cache_manager/src/cache_store.dart';
 import 'package:flutter_cache_manager/src/compat/file_service_compat.dart';
 import 'package:flutter_cache_manager/src/result/download_progress.dart';
+import 'package:flutter_cache_manager/src/result/file_info.dart';
 import 'package:flutter_cache_manager/src/result/file_response.dart';
 import 'package:flutter_cache_manager/src/storage/cache_object.dart';
-import 'package:flutter_cache_manager/src/cache_store.dart';
 import 'package:flutter_cache_manager/src/storage/non_storing_object_provider.dart';
 import 'package:flutter_cache_manager/src/web/file_service.dart';
-import 'package:flutter_cache_manager/src/result/file_info.dart';
 import 'package:flutter_cache_manager/src/web/web_helper.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
@@ -98,6 +98,9 @@ abstract class BaseCacheManager {
 
   /// Store helper for cached files
   CacheStore _store;
+
+  /// Get the underlying store helper
+  CacheStore get store => _store;
 
   /// WebHelper to download and store files
   WebHelper _webHelper;

--- a/flutter_cache_manager/lib/src/cache_store.dart
+++ b/flutter_cache_manager/lib/src/cache_store.dart
@@ -49,8 +49,9 @@ class CacheStore {
     return provider;
   }
 
-  Future<FileInfo> getFile(String url) async {
-    final cacheObject = await retrieveCacheData(url);
+  Future<FileInfo> getFile(String url, {bool ignoreMemCache = false}) async {
+    final cacheObject =
+        await retrieveCacheData(url, ignoreMemCache: ignoreMemCache);
     if (cacheObject == null || cacheObject.relativePath == null) {
       return null;
     }
@@ -63,8 +64,9 @@ class CacheStore {
     await _updateCacheDataInDatabase(cacheObject);
   }
 
-  Future<CacheObject> retrieveCacheData(String url) {
-    if (_memCache.containsKey(url)) {
+  Future<CacheObject> retrieveCacheData(String url,
+      {bool ignoreMemCache = false}) {
+    if (!ignoreMemCache && _memCache.containsKey(url)) {
       return Future.value(_memCache[url]);
     }
     if (!_futureCache.containsKey(url)) {
@@ -78,7 +80,7 @@ class CacheStore {
         completer.complete(cacheObject);
 
         _memCache[url] = cacheObject;
-        _futureCache.remove(url);
+        unawaited(_futureCache.remove(url));
       });
       _futureCache[url] = completer.future;
     }

--- a/flutter_cache_manager/lib/src/cache_store.dart
+++ b/flutter_cache_manager/lib/src/cache_store.dart
@@ -2,9 +2,9 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:file/file.dart' as f;
+import 'package:flutter_cache_manager/src/result/file_info.dart';
 import 'package:flutter_cache_manager/src/storage/cache_info_repository.dart';
 import 'package:flutter_cache_manager/src/storage/cache_object.dart';
-import 'package:flutter_cache_manager/src/result/file_info.dart';
 import 'package:flutter_cache_manager/src/storage/cache_object_provider.dart';
 import 'package:path/path.dart' as p;
 import 'package:pedantic/pedantic.dart';
@@ -78,7 +78,7 @@ class CacheStore {
         completer.complete(cacheObject);
 
         _memCache[url] = cacheObject;
-        _futureCache[url] = null;
+        _futureCache.remove(url);
       });
       _futureCache[url] = completer.future;
     }
@@ -154,6 +154,10 @@ class CacheStore {
       unawaited(_removeCachedFile(cacheObject, toRemove));
     }
     await provider.deleteAll(toRemove);
+  }
+
+  void emptyMemoryCache() {
+    _memCache.clear();
   }
 
   Future<void> removeCachedFile(CacheObject cacheObject) async {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (feature)

Currently the `CacheStore` has its own `_memCache` to cache the results from db. However, if the db is modified in another cache store instance (with same configuration, i.e. fileDir) that the store is not aware of, and the user has no control over the staled items in memory.

I think we should at least provide some way to explicitly (if not auto) invalidate the whole or single item from the memory. (maybe adding a flag to `getFile`/`retrieveCacheData` to bypass memory)

### :arrow_heading_down: What is the current behavior?
If the db is modified outside of the current vm, the only way to reload the cache store is to dispose and create a new one. However, this is not elegant and also most of the time these are long lived singletons, making it very hard to replace the whole object.

### :new: What is the new behavior?
Added method to clear the `_memCache` and added a flag to bypass when fetching a single item. 
Also added some getters in `BaseCacheManager` to expose the underlying store/web helpers

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing
1. Create two instances (A, B) of `BaseCacheManager`, with the same `getFilePath()`.
2. put an item in instance A
3. get the item in instance B, it should work since this is the first time
4. remove/update the item in A
5. get again in B, this will return a staled db record, but if you read the file, content is updated (since the file system does not cache). In case you removed the item in step 4, the staled record will still be returned, even though the file has been deleted.

Add item follows the same logic. If you have once get a non existing key in B, it will cache the `null` result.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
