### PR TITLE
Don't delete file when file is already being deleted

### DIFF
--- a/flutter_cache_manager/lib/src/cache_store.dart
+++ b/flutter_cache_manager/lib/src/cache_store.dart
@@ -171,14 +171,14 @@ class CacheStore {
 
   Future<void> _removeCachedFile(
       CacheObject cacheObject, List<int> toRemove) async {
-    if (!toRemove.contains(cacheObject.id)) {
-      toRemove.add(cacheObject.id);
-      if (_memCache.containsKey(cacheObject.url)) {
-        _memCache.remove(cacheObject.url);
-      }
-      if (_futureCache.containsKey(cacheObject.url)) {
-        unawaited(_futureCache.remove(cacheObject.url));
-      }
+    if (toRemove.contains(cacheObject.id)) return;
+
+    toRemove.add(cacheObject.id);
+    if (_memCache.containsKey(cacheObject.url)) {
+      _memCache.remove(cacheObject.url);
+    }
+    if (_futureCache.containsKey(cacheObject.url)) {
+      unawaited(_futureCache.remove(cacheObject.url));
     }
     final file = (await fileDir).childFile(cacheObject.relativePath);
     if (await file.exists()) {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix

### :arrow_heading_down: What is the current behavior?

When a file is old and over capacity the store tries to delete the file twice

### :new: What is the new behavior (if this is a feature change)?

It only deletes it once.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
I wrote a test, but it didn't fail, because file.exists() is very fast with memory filesystem. Automated testing only realy works when you force a delay in the code, which is not nice.

### :memo: Links to relevant issues/docs
fixes #184 and fixes https://github.com/Baseflow/flutter_cached_network_image/issues/335

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
