### PR TITLE
Check if file in mem cache exists

### DIFF
--- a/flutter_cache_manager/lib/src/cache_store.dart
+++ b/flutter_cache_manager/lib/src/cache_store.dart
@@ -65,9 +65,9 @@ class CacheStore {
   }
 
   Future<CacheObject> retrieveCacheData(String url,
-      {bool ignoreMemCache = false}) async{
+      {bool ignoreMemCache = false}) async {
     if (!ignoreMemCache && _memCache.containsKey(url)) {
-      if(await _fileExists(_memCache[url])){
+      if (await _fileExists(_memCache[url])) {
         return _memCache[url];
       }
     }
@@ -79,7 +79,7 @@ class CacheStore {
           await provider.delete(cacheObject.id);
           cacheObject = null;
         }
-        
+
         _memCache[url] = cacheObject;
         completer.complete(cacheObject);
         unawaited(_futureCache.remove(url));

--- a/flutter_cache_manager/test/cache_store_test.dart
+++ b/flutter_cache_manager/test/cache_store_test.dart
@@ -228,6 +228,26 @@ void main() {
       verify(repo.deleteAll(argThat(contains(cacheObject.id)))).called(1);
     });
 
+    test('Store should recheck cache info when file is removed', () async {
+      var repo = MockRepo();
+      var directory = createDir();
+
+      var store = CacheStore(directory, 'test', 2, const Duration(days: 7),
+          cacheRepoProvider: Future.value(repo),
+          cleanupRunMinInterval: const Duration());
+
+      var cacheObject = CacheObject('baseflow.com/test.png',
+          relativePath: 'testimage.png', id: 1);
+      var file = await (await directory).childFile('testimage.png').create();
+
+      when(repo.get('baseflow.com/test.png'))
+          .thenAnswer((_) => Future.value(cacheObject));
+
+      expect(await store.getFile('baseflow.com/test.png'), isNotNull);
+      await file.delete();
+      expect(await store.getFile('baseflow.com/test.png'), isNull);
+    });
+
     test('Store should not remove files that are not old or over capacity',
         () async {
       var repo = MockRepo();

--- a/flutter_cache_manager/test/cache_store_test.dart
+++ b/flutter_cache_manager/test/cache_store_test.dart
@@ -240,6 +240,10 @@ void main() {
           relativePath: 'testimage.png', id: 1);
       var file = await (await directory).childFile('testimage.png').create();
 
+      when(repo.getObjectsOverCapacity(any))
+          .thenAnswer((_) => Future.value([]));
+      when(repo.getOldObjects(any))
+          .thenAnswer((_) => Future.value([]));
       when(repo.get('baseflow.com/test.png'))
           .thenAnswer((_) => Future.value(cacheObject));
 


### PR DESCRIPTION
Could fix #135

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Currently the store doesn't check if a file exists when it has a CacheObject in memory.
When the file is removed by the file system the store still returns it as though the file does exist.

### :new: What is the new behavior (if this is a feature change)?
When return the object in memory it checks if the file exists and doesn't return it otherwise.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
I tested the example app with the flow in https://github.com/Baseflow/flutter_cache_manager/issues/135#issuecomment-638753854

In the old situation I could clear the cache and the app still says it loads the file from cache. In the new situation it downloads the file again.

### :memo: Links to relevant issues/docs
Fixes #135 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
