### PR TITLE
Store length in database

### DIFF
--- a/flutter_cache_manager/lib/src/storage/cache_object.dart
+++ b/flutter_cache_manager/lib/src/storage/cache_object.dart
@@ -13,6 +13,7 @@ class CacheObject {
   static const columnETag = 'eTag';
   static const columnValidTill = 'validTill';
   static const columnTouched = 'touched';
+  static const columnLength = 'length';
 
   CacheObject(
     this.url, {
@@ -21,6 +22,7 @@ class CacheObject {
     this.validTill,
     this.eTag,
     this.id,
+    this.length,
   }) {
     key ??= url;
   }
@@ -32,7 +34,8 @@ class CacheObject {
         relativePath = map[columnPath] as String,
         validTill =
             DateTime.fromMillisecondsSinceEpoch(map[columnValidTill] as int),
-        eTag = map[columnETag] as String;
+        eTag = map[columnETag] as String,
+        length = map[columnLength] as int;
 
   /// Internal ID used to represent this cache object
   int id;
@@ -54,6 +57,9 @@ class CacheObject {
   /// eTag provided by the server for cache expiry
   String eTag;
 
+  /// The length of the cached file
+  int length;
+
   Map<String, dynamic> toMap() {
     final map = <String, dynamic>{
       columnUrl: url,
@@ -61,7 +67,8 @@ class CacheObject {
       columnPath: relativePath,
       columnETag: eTag,
       columnValidTill: validTill?.millisecondsSinceEpoch ?? 0,
-      columnTouched: clock.now().millisecondsSinceEpoch
+      columnTouched: clock.now().millisecondsSinceEpoch,
+      columnLength: length,
     };
     if (id != null) {
       map[columnId] = id;

--- a/flutter_cache_manager/lib/src/storage/cache_object_provider.dart
+++ b/flutter_cache_manager/lib/src/storage/cache_object_provider.dart
@@ -22,7 +22,8 @@ class CacheObjectProvider implements CacheInfoRepository {
         ${CacheObject.columnPath} text,
         ${CacheObject.columnETag} text,
         ${CacheObject.columnValidTill} integer,
-        ${CacheObject.columnTouched} integer
+        ${CacheObject.columnTouched} integer,
+        ${CacheObject.columnLength} integer
         );
         create unique index $_tableCacheObject${CacheObject.columnKey} 
         ON $_tableCacheObject (${CacheObject.columnKey});
@@ -34,7 +35,9 @@ class CacheObjectProvider implements CacheInfoRepository {
       // Migrates over any existing URLs to keys
       if (oldVersion == 1) {
         await db.execute('''
-        alter table $_tableCacheObject add ${CacheObject.columnKey} text;
+        alter table $_tableCacheObject 
+        add ${CacheObject.columnKey} text
+        add ${CacheObject.columnLength} integer;
 
         update $_tableCacheObject 
           set ${CacheObject.columnKey} = ${CacheObject.columnUrl}

--- a/flutter_cache_manager/lib/src/storage/cache_object_provider.dart
+++ b/flutter_cache_manager/lib/src/storage/cache_object_provider.dart
@@ -12,7 +12,7 @@ class CacheObjectProvider implements CacheInfoRepository {
 
   @override
   Future open() async {
-    db = await openDatabase(path, version: 2,
+    db = await openDatabase(path, version: 3,
         onCreate: (Database db, int version) async {
       await db.execute('''
       create table $_tableCacheObject ( 
@@ -36,8 +36,7 @@ class CacheObjectProvider implements CacheInfoRepository {
       if (oldVersion <= 1) {
         await db.execute('''
         alter table $_tableCacheObject 
-        add ${CacheObject.columnKey} text,
-            ${CacheObject.columnLength} integer;
+        add ${CacheObject.columnKey} text;
 
         update $_tableCacheObject 
           set ${CacheObject.columnKey} = ${CacheObject.columnUrl}
@@ -45,6 +44,12 @@ class CacheObjectProvider implements CacheInfoRepository {
 
         create unique index $_tableCacheObject${CacheObject.columnKey} 
           on $_tableCacheObject (${CacheObject.columnKey});
+        ''');
+      }
+      if (oldVersion <= 2) {
+        await db.execute('''
+        alter table $_tableCacheObject 
+        add ${CacheObject.columnLength} integer;
         ''');
       }
     });

--- a/flutter_cache_manager/lib/src/storage/cache_object_provider.dart
+++ b/flutter_cache_manager/lib/src/storage/cache_object_provider.dart
@@ -33,11 +33,11 @@ class CacheObjectProvider implements CacheInfoRepository {
       // Adds the new column
       // Creates a unique index for the column
       // Migrates over any existing URLs to keys
-      if (oldVersion == 1) {
+      if (oldVersion <= 1) {
         await db.execute('''
         alter table $_tableCacheObject 
-        add ${CacheObject.columnKey} text
-        add ${CacheObject.columnLength} integer;
+        add ${CacheObject.columnKey} text,
+            ${CacheObject.columnLength} integer;
 
         update $_tableCacheObject 
           set ${CacheObject.columnKey} = ${CacheObject.columnUrl}

--- a/flutter_cache_manager/lib/src/web/web_helper.dart
+++ b/flutter_cache_manager/lib/src/web/web_helper.dart
@@ -96,11 +96,14 @@ class WebHelper {
     var newCacheFile = cacheObject.relativePath;
     _setDataFromHeaders(cacheObject, response);
     if (statusCodesNewFile.contains(response.statusCode)) {
+      int savedBytes;
       await for (var progress in _saveFile(cacheObject, response)) {
+        savedBytes = progress;
         yield DownloadProgress(
             cacheObject.url, response.contentLength, progress);
       }
       newCacheFile = cacheObject.relativePath;
+      cacheObject.length = savedBytes;
     }
 
     unawaited(_store.putFile(cacheObject).then((_) {
@@ -121,7 +124,6 @@ class WebHelper {
       unawaited(_removeOldFile(oldPath));
       cacheObject.relativePath = null;
     }
-
     cacheObject.relativePath ??= '${Uuid().v1()}$fileExtension';
   }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
feature

### :arrow_heading_down: What is the current behavior?
Current size of the file is not stored in the database, and thus not readily available.

### :new: What is the new behavior (if this is a feature change)?
Store length of the file to the database. Can be useful for smarter cache management.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
