### PR TITLE
immutability of CacheObject

### DIFF
--- a/flutter_cache_manager/lib/src/cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_manager.dart
@@ -240,8 +240,11 @@ abstract class BaseCacheManager {
     var cacheObject = await _store.retrieveCacheData(key);
     cacheObject ??= CacheObject(url,
         key: key, relativePath: '${Uuid().v1()}.$fileExtension');
-    cacheObject.validTill = DateTime.now().add(maxAge);
-    cacheObject.eTag = eTag;
+
+    cacheObject = cacheObject.copyWith(
+      validTill: DateTime.now().add(maxAge),
+      eTag: eTag,
+    );
 
     final file = (await _fileDir).childFile(cacheObject.relativePath);
     final folder = file.parent;

--- a/flutter_cache_manager/lib/src/storage/cache_object.dart
+++ b/flutter_cache_manager/lib/src/storage/cache_object.dart
@@ -23,7 +23,7 @@ class CacheObject {
     this.eTag,
     this.id,
     this.length,
-  }): key = key ?? url;
+  }) : key = key ?? url;
 
   CacheObject.fromMap(Map<String, dynamic> map)
       : id = map[columnId] as int,
@@ -78,12 +78,16 @@ class CacheObject {
     return list.map((map) => CacheObject.fromMap(map)).toList();
   }
 
-  CacheObject copyWith({int id,
+  CacheObject copyWith({
+    String url,
+    int id,
     String relativePath,
     DateTime validTill,
     String eTag,
-  int length,}){
-    return CacheObject(url,
+    int length,
+  }) {
+    return CacheObject(
+      url ?? this.url,
       id: id ?? this.id,
       key: key,
       relativePath: relativePath ?? this.relativePath,

--- a/flutter_cache_manager/lib/src/storage/cache_object.dart
+++ b/flutter_cache_manager/lib/src/storage/cache_object.dart
@@ -17,15 +17,13 @@ class CacheObject {
 
   CacheObject(
     this.url, {
-    this.key,
+    String key,
     this.relativePath,
     this.validTill,
     this.eTag,
     this.id,
     this.length,
-  }) {
-    key ??= url;
-  }
+  }): key = key ?? url;
 
   CacheObject.fromMap(Map<String, dynamic> map)
       : id = map[columnId] as int,
@@ -38,27 +36,27 @@ class CacheObject {
         length = map[columnLength] as int;
 
   /// Internal ID used to represent this cache object
-  int id;
+  final int id;
 
   /// The URL that was used to download the file
-  String url;
+  final String url;
 
   /// The key used to identify the object in the cache.
   ///
   /// This key is optional and will default to [url] if not specified
-  String key;
+  final String key;
 
   /// Where the cached file is stored
-  String relativePath;
+  final String relativePath;
 
   /// When this cached item becomes invalid
-  DateTime validTill;
+  final DateTime validTill;
 
   /// eTag provided by the server for cache expiry
-  String eTag;
+  final String eTag;
 
   /// The length of the cached file
-  int length;
+  final int length;
 
   Map<String, dynamic> toMap() {
     final map = <String, dynamic>{
@@ -78,5 +76,20 @@ class CacheObject {
 
   static List<CacheObject> fromMapList(List<Map<String, dynamic>> list) {
     return list.map((map) => CacheObject.fromMap(map)).toList();
+  }
+
+  CacheObject copyWith({int id,
+    String relativePath,
+    DateTime validTill,
+    String eTag,
+  int length,}){
+    return CacheObject(url,
+      id: id ?? this.id,
+      key: key,
+      relativePath: relativePath ?? this.relativePath,
+      validTill: validTill ?? this.validTill,
+      eTag: eTag ?? this.eTag,
+      length: length ?? this.length,
+    );
   }
 }

--- a/flutter_cache_manager/lib/src/storage/cache_object_provider.dart
+++ b/flutter_cache_manager/lib/src/storage/cache_object_provider.dart
@@ -61,8 +61,8 @@ class CacheObjectProvider implements CacheInfoRepository {
 
   @override
   Future<CacheObject> insert(CacheObject cacheObject) async {
-    cacheObject.id = await db.insert(_tableCacheObject, cacheObject.toMap());
-    return cacheObject;
+    var id = await db.insert(_tableCacheObject, cacheObject.toMap());
+    return cacheObject.copyWith(id: id);
   }
 
   @override

--- a/flutter_cache_manager/lib/src/web/web_helper.dart
+++ b/flutter_cache_manager/lib/src/web/web_helper.dart
@@ -58,7 +58,9 @@ class WebHelper {
   Stream<FileResponse> _updateFile(String url, String key,
       {Map<String, String> authHeaders}) async* {
     var cacheObject = await _store.retrieveCacheData(key);
-    cacheObject ??= CacheObject(url, key: key);
+    cacheObject = cacheObject == null
+        ? CacheObject(url, key: key)
+        : cacheObject.copyWith(url: url);
     final response = await _download(cacheObject, authHeaders);
     yield* _manageResponse(cacheObject, response);
 
@@ -116,8 +118,9 @@ class WebHelper {
     final fileExtension = response.fileExtension;
     var filePath = cacheObject.relativePath;
 
-    if (filePath != null && !statusCodesFileNotChanged.contains(response.statusCode)) {
-      if(!filePath.endsWith(fileExtension)) {
+    if (filePath != null &&
+        !statusCodesFileNotChanged.contains(response.statusCode)) {
+      if (!filePath.endsWith(fileExtension)) {
         //Delete old file directly when file extension changed
         unawaited(_removeOldFile(filePath));
       }

--- a/flutter_cache_manager/test/cache_manager_test.dart
+++ b/flutter_cache_manager/test/cache_manager_test.dart
@@ -338,7 +338,7 @@ void main() {
     });
   });
 
-  group('Testing puting files in cache', () {
+  group('Testing putting files in cache', () {
     test('Check if file is written and info is stored', () async {
       var fileUrl = 'baseflow.com/test';
       var fileBytes = Uint8List(16);
@@ -357,6 +357,7 @@ void main() {
       expect(await file.readAsBytes(), fileBytes);
       verify(store.putFile(any)).called(1);
     });
+
     test('Check if file is written and info is stored, explicit key', () async {
       var fileUrl = 'baseflow.com/test';
       var fileBytes = Uint8List(16);

--- a/flutter_cache_manager/test/cache_object_test.dart
+++ b/flutter_cache_manager/test/cache_object_test.dart
@@ -15,6 +15,12 @@ void main() {
   final validDate = DateTime.utc(2020, 03, 27, 09, 26).toLocal();
   final now = DateTime(2020, 03, 28, 09, 26);
 
+  final testId = 1;
+  final relativePath = 'test.png';
+  final testUrl = 'www.test.com/image';
+  final testKey = 'test123';
+  final eTag = 'test1';
+
   test('constructor, no explicit key', () {
     final object = CacheObject(
       'baseflow.com/test.png',
@@ -98,6 +104,108 @@ void main() {
         expect(map[columnValidTill], validMillis);
         expect(map[columnTouched], now.millisecondsSinceEpoch);
       });
+    });
+  });
+
+  group('Test CacheObject copy', () {
+    test('copy with id', () {
+      var cacheObject = CacheObject(
+        testUrl,
+        id: null,
+        key: testKey,
+        relativePath: relativePath,
+        validTill: now,
+        eTag: eTag,
+        length: 200,
+      );
+      var newObject = cacheObject.copyWith(id: testId);
+      expect(newObject.id, testId);
+      expect(newObject.url, testUrl);
+      expect(newObject.key, testKey);
+      expect(newObject.relativePath, relativePath);
+      expect(newObject.validTill, now);
+      expect(newObject.eTag, eTag);
+      expect(newObject.length, 200);
+    });
+
+    test('copy with path', () {
+      var cacheObject = CacheObject(
+        testUrl,
+        id: testId,
+        key: testKey,
+        relativePath: relativePath,
+        validTill: now,
+        eTag: eTag,
+        length: 200,
+      );
+      var newObject = cacheObject.copyWith(relativePath: 'newPath.jpg');
+      expect(newObject.id, testId);
+      expect(newObject.url, testUrl);
+      expect(newObject.key, testKey);
+      expect(newObject.relativePath, 'newPath.jpg');
+      expect(newObject.validTill, now);
+      expect(newObject.eTag, eTag);
+      expect(newObject.length, 200);
+    });
+
+    test('copy with validTill', () {
+      var cacheObject = CacheObject(
+        testUrl,
+        id: testId,
+        key: testKey,
+        relativePath: relativePath,
+        validTill: now,
+        eTag: eTag,
+        length: 200,
+      );
+      var newObject = cacheObject.copyWith(validTill: validDate);
+      expect(newObject.id, testId);
+      expect(newObject.url, testUrl);
+      expect(newObject.key, testKey);
+      expect(newObject.relativePath, relativePath);
+      expect(newObject.validTill, validDate);
+      expect(newObject.eTag, eTag);
+      expect(newObject.length, 200);
+    });
+
+    test('copy with eTag', () {
+      var cacheObject = CacheObject(
+        testUrl,
+        id: testId,
+        key: testKey,
+        relativePath: relativePath,
+        validTill: now,
+        eTag: eTag,
+        length: 200,
+      );
+      var newObject = cacheObject.copyWith(eTag: 'fileChangedRecently');
+      expect(newObject.id, testId);
+      expect(newObject.url, testUrl);
+      expect(newObject.key, testKey);
+      expect(newObject.relativePath, relativePath);
+      expect(newObject.validTill, now);
+      expect(newObject.eTag, 'fileChangedRecently');
+      expect(newObject.length, 200);
+    });
+
+    test('copy with length', () {
+      var cacheObject = CacheObject(
+        testUrl,
+        id: testId,
+        key: testKey,
+        relativePath: relativePath,
+        validTill: now,
+        eTag: eTag,
+        length: 200,
+      );
+      var newObject = cacheObject.copyWith(length: 300);
+      expect(newObject.id, testId);
+      expect(newObject.url, testUrl);
+      expect(newObject.key, testKey);
+      expect(newObject.relativePath, relativePath);
+      expect(newObject.validTill, now);
+      expect(newObject.eTag, eTag);
+      expect(newObject.length, 300);
     });
   });
 }

--- a/flutter_cache_manager/test/cache_object_test.dart
+++ b/flutter_cache_manager/test/cache_object_test.dart
@@ -128,6 +128,27 @@ void main() {
       expect(newObject.length, 200);
     });
 
+    test('copy with url', () {
+      var cacheObject = CacheObject(
+        testUrl,
+        id: testId,
+        key: testKey,
+        relativePath: relativePath,
+        validTill: now,
+        eTag: eTag,
+        length: 200,
+      );
+      const newUrl = 'www.someotherurl.com';
+      final newObject = cacheObject.copyWith(url: newUrl);
+      expect(newObject.id, testId);
+      expect(newObject.url, newUrl);
+      expect(newObject.key, testKey);
+      expect(newObject.relativePath, relativePath);
+      expect(newObject.validTill, now);
+      expect(newObject.eTag, eTag);
+      expect(newObject.length, 200);
+    });
+
     test('copy with path', () {
       var cacheObject = CacheObject(
         testUrl,


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
(Potential) bug fix

### :arrow_heading_down: What is the current behavior?
A CacheObject which is returned from the store is changed in several places. The path is changed before the file is saved, which means it can happen that that same cacheobject is used somewhere else and returned to the user of the lib.

### :new: What is the new behavior (if this is a feature change)?
CacheObject is immutable and needs to be copied with new values.

### :boom: Does this PR introduce a breaking change?
No, CacheObjects are not used outside of this library.

### :bug: Recommendations for testing
The potential bug is hard to reproduce, but tests are added.

### :memo: Links to relevant issues/docs
Potential bugs:
#135
#184 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
