### PR TITLE
Webhelper returned old cacheinformation

### DIFF
--- a/flutter_cache_manager/lib/src/web/web_helper.dart
+++ b/flutter_cache_manager/lib/src/web/web_helper.dart
@@ -63,9 +63,6 @@ class WebHelper {
         : cacheObject.copyWith(url: url);
     final response = await _download(cacheObject, authHeaders);
     yield* _manageResponse(cacheObject, response);
-
-    final file = (await _store.fileDir).childFile(cacheObject.relativePath);
-    yield FileInfo(file, FileSource.Online, cacheObject.validTill, url);
   }
 
   Future<FileServiceResponse> _download(
@@ -82,7 +79,7 @@ class WebHelper {
     return _fileFetcher.get(cacheObject.url, headers: headers);
   }
 
-  Stream<DownloadProgress> _manageResponse(
+  Stream<FileResponse> _manageResponse(
       CacheObject cacheObject, FileServiceResponse response) async* {
     final hasNewFile = statusCodesNewFile.contains(response.statusCode);
     final keepOldFile = statusCodesFileNotChanged.contains(response.statusCode);
@@ -111,6 +108,14 @@ class WebHelper {
         _removeOldFile(oldCacheObject.relativePath);
       }
     }));
+
+    final file = (await _store.fileDir).childFile(newCacheObject.relativePath);
+    yield FileInfo(
+      file,
+      FileSource.Online,
+      newCacheObject.validTill,
+      newCacheObject.url,
+    );
   }
 
   CacheObject _setDataFromHeaders(


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
While making the CacheObjects immutable a bug was introduced. The WebHelper returns information from the old CacheObject when updating the file.

### :new: What is the new behavior (if this is a feature change)?
The new information (path and validity) is returned

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
The example was broken when you clean the cache. Works now.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
