### PR TITLE
Expand `file` version constraints to include version 6 (with NNBD)

### DIFF
--- a/flutter_cache_manager/pubspec.yaml
+++ b/flutter_cache_manager/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   sqflite: "^1.1.7+2"
   pedantic: "^1.8.0+1"
   clock: ^1.0.1
-  file: ^5.1.0
+  file: ">=5.0.0 <7.0.0"
   rxdart: '>=0.23.1 <0.25.0'
   
 dev_dependencies:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

The Flutter repo and plugins are being migrated to NNBD.

The most recent changes (that I know of) is the file package version `6.0.0-nullsafety.1`. If an app:

1. Depends on `flutter_cache_manager`, `flutter_driver` from sdk
2. Uses Flutter dev channel

Executing `pub get` will fail with something like this:

```
And because flutter_cache_manager >=1.2.0 depends on file ^5.1.0 and every version of flutter_driver from sdk depends on file 6.0.0-nullsafety.1, flutter_widget_from_html from path is incompatible with flutter_driver from sdk.
```

### :new: What is the new behavior (if this is a feature change)?

`pub get` should stop complaining.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

This PR expand the version constraints of the `file` dependency to allow both v5 and v6.
Testing seems to be unaffected but there are some [breaking changes][1] between file@5 and file@6 so it may be actually unsafe to do this...

[1]: https://github.com/google/file.dart/blob/master/packages/file/CHANGELOG.md

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
