### PR TITLE
Bumped file dep to 6.0.0-nullsafety.1 to fix versioning errors in Flutter 1.22 (dev/master channel)

### DIFF
--- a/flutter_cache_manager/example/lib/main.dart
+++ b/flutter_cache_manager/example/lib/main.dart
@@ -116,7 +116,7 @@ class Fab extends StatelessWidget {
     return FloatingActionButton(
       onPressed: downloadFile,
       tooltip: 'Download',
-      child: Icon(Icons.cloud_download),
+      child: const Icon(Icons.cloud_download),
     );
   }
 }

--- a/flutter_cache_manager/lib/src/compat/file_fetcher.dart
+++ b/flutter_cache_manager/lib/src/compat/file_fetcher.dart
@@ -12,7 +12,7 @@ typedef Future<FileFetcherResponse> FileFetcher(String url,
     {Map<String, String> headers});
 
 abstract class FileFetcherResponse {
-  get statusCode;
+  int get statusCode;
 
   Uint8List get bodyBytes => null;
 
@@ -22,7 +22,7 @@ abstract class FileFetcherResponse {
 }
 
 class HttpFileFetcherResponse implements FileFetcherResponse {
-  http.Response _response;
+  final http.Response _response;
 
   HttpFileFetcherResponse(this._response);
 
@@ -40,5 +40,5 @@ class HttpFileFetcherResponse implements FileFetcherResponse {
   Uint8List get bodyBytes => _response.bodyBytes;
 
   @override
-  get statusCode => _response.statusCode;
+  int get statusCode => _response.statusCode;
 }

--- a/flutter_cache_manager/lib/src/compat/file_service_compat.dart
+++ b/flutter_cache_manager/lib/src/compat/file_service_compat.dart
@@ -79,5 +79,5 @@ class CompatFileServiceGetResponse implements FileServiceResponse {
   }
 
   @override
-  int get statusCode => legacyResponse.statusCode as int;
+  int get statusCode => legacyResponse.statusCode;
 }

--- a/flutter_cache_manager/lib/src/storage/cache_object_provider.dart
+++ b/flutter_cache_manager/lib/src/storage/cache_object_provider.dart
@@ -34,7 +34,6 @@ class CacheObjectProvider implements CacheInfoRepository {
       // Creates a unique index for the column
       // Migrates over any existing URLs to keys
       if (oldVersion <= 1) {
-
         await db.transaction((txn) async {
           await txn.execute('''
             alter table $_tableCacheObject 

--- a/flutter_cache_manager/pubspec.yaml
+++ b/flutter_cache_manager/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_cache_manager
 description: Generic cache manager for flutter. Saves web files on the storages of the device and saves the cache info using sqflite.
-version: 1.4.1
+version: 1.4.2
 homepage: https://github.com/Baseflow/flutter_cache_manager
 
 environment:
@@ -16,7 +16,7 @@ dependencies:
   sqflite: "^1.1.7+2"
   pedantic: "^1.8.0+1"
   clock: ^1.0.1
-  file: ^5.1.0
+  file: ^6.0.0-nullsafety.1
   rxdart: '>=0.23.1 <0.25.0'
   
 dev_dependencies:

--- a/flutter_cache_manager/test/cache_manager_test.dart
+++ b/flutter_cache_manager/test/cache_manager_test.dart
@@ -183,7 +183,7 @@ void main() {
       var webHelper = MockWebHelper();
       var cacheManager = TestCacheManager(store, webHelper);
 
-      var fileStream = cacheManager.getFile(fileUrl);
+      var fileStream = cacheManager.getFileStream(fileUrl);
       expect(fileStream, emits(fileInfo));
       verifyNever(webHelper.downloadFile(any));
     });
@@ -208,7 +208,7 @@ void main() {
           .thenAnswer((_) => Stream.value(downloadedInfo));
 
       var cacheManager = TestCacheManager(store, webHelper);
-      var fileStream = cacheManager.getFile(fileUrl);
+      var fileStream = cacheManager.getFileStream(fileUrl);
       await expectLater(fileStream, emitsInOrder([cachedInfo, downloadedInfo]));
 
       verify(webHelper.downloadFile(any, key: anyNamed('key'))).called(1);
@@ -233,7 +233,7 @@ void main() {
 
       var cacheManager = TestCacheManager(store, webHelper);
 
-      var fileStream = cacheManager.getFile(fileUrl);
+      var fileStream = cacheManager.getFileStream(fileUrl);
       await expectLater(fileStream, emitsInOrder([fileInfo]));
       verify(webHelper.downloadFile(any, key: anyNamed('key'))).called(1);
     });
@@ -252,7 +252,7 @@ void main() {
 
       var cacheManager = TestCacheManager(store, webHelper);
 
-      var fileStream = cacheManager.getFile(fileUrl);
+      var fileStream = cacheManager.getFileStream(fileUrl);
       await expectLater(fileStream, emitsError(error));
       verify(webHelper.downloadFile(any, key: anyNamed('key'))).called(1);
     });
@@ -273,7 +273,7 @@ void main() {
         var webHelper = MockWebHelper();
         var cacheManager = TestCacheManager(store, webHelper);
 
-        var fileStream = cacheManager.getFile(fileUrl, key: fileKey);
+        var fileStream = cacheManager.getFileStream(fileUrl, key: fileKey);
         expect(fileStream, emits(fileInfo));
         verifyNever(webHelper.downloadFile(any));
       });
@@ -300,7 +300,7 @@ void main() {
             .thenAnswer((_) => Stream.value(downloadedInfo));
 
         var cacheManager = TestCacheManager(store, webHelper);
-        var fileStream = cacheManager.getFile(fileUrl, key: fileKey);
+        var fileStream = cacheManager.getFileStream(fileUrl, key: fileKey);
         await expectLater(
             fileStream, emitsInOrder([cachedInfo, downloadedInfo]));
 
@@ -329,7 +329,7 @@ void main() {
 
         var cacheManager = TestCacheManager(store, webHelper);
 
-        var fileStream = cacheManager.getFile(fileUrl, key: fileKey);
+        var fileStream = cacheManager.getFileStream(fileUrl, key: fileKey);
         await expectLater(fileStream, emitsInOrder([fileInfo]));
         verify(webHelper.downloadFile(any,
                 key: argThat(equals('test1234'), named: 'key')))

--- a/flutter_cache_manager/test/cache_store_test.dart
+++ b/flutter_cache_manager/test/cache_store_test.dart
@@ -197,8 +197,6 @@ void main() {
       verify(repo.deleteAll(argThat(contains(cacheObject.id)))).called(1);
     });
 
-
-
     test('Store should remove file old and over capacity', () async {
       var repo = MockRepo();
       var directory = createDir();
@@ -209,7 +207,7 @@ void main() {
 
       var cacheObject = CacheObject('baseflow.com/test.png',
           relativePath: 'testimage.png', id: 1);
-      var file = await (await directory).childFile('testimage.png').create();
+      await (await directory).childFile('testimage.png').create();
 
       when(repo.getObjectsOverCapacity(any))
           .thenAnswer((_) => Future.value([cacheObject]));
@@ -242,8 +240,7 @@ void main() {
 
       when(repo.getObjectsOverCapacity(any))
           .thenAnswer((_) => Future.value([]));
-      when(repo.getOldObjects(any))
-          .thenAnswer((_) => Future.value([]));
+      when(repo.getOldObjects(any)).thenAnswer((_) => Future.value([]));
       when(repo.get('baseflow.com/test.png'))
           .thenAnswer((_) => Future.value(cacheObject));
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix so the library can be used in Flutter 1.22 again.

### :arrow_heading_down: What is the current behavior?
`flutter_cache_manager` cannot be used in Flutter 1.22 due to a pub versioning issue with the File dependency.

### :new: What is the new behavior (if this is a feature change)?
Plugin works again.

Also fixed the analyzer warnings following CONTRIBUTING.md.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
None.

### :memo: Links to relevant issues/docs
https://github.com/Baseflow/flutter_cache_manager/issues/216

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
