### PR TITLE
Update to support firebase storage 4.0.0+

### DIFF
--- a/flutter_cache_manager_firebase/pubspec.yaml
+++ b/flutter_cache_manager_firebase/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_cache_manager: ^1.0.0
-  firebase_storage: ^4.0.0
+  firebase_storage: '>=3.0.0 <5.0.0'
   path_provider: "^1.4.0"
   path: "^1.6.4"
 

--- a/flutter_cache_manager_firebase/pubspec.yaml
+++ b/flutter_cache_manager_firebase/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_cache_manager: ^1.0.0
-  firebase_storage: ^3.0.0
+  firebase_storage: ^4.0.0
   path_provider: "^1.4.0"
   path: "^1.6.4"
 

--- a/flutter_cache_manager_firebase/pubspec.yaml
+++ b/flutter_cache_manager_firebase/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_cache_manager: ^1.0.0
+  firebase_core: "^0.5.0"
   firebase_storage: '>=3.0.0 <5.0.0'
   path_provider: "^1.4.0"
   path: "^1.6.4"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Update dependency

### :arrow_heading_down: What is the current behavior?
`flutter_cache_manager_firebase` does not support `firebase_storage >= 4.0.0`

### :new: What is the new behavior (if this is a feature change)?
`flutter_cache_manager_firebase` to support `firebase_storage >= 4.0.0`

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
https://firebase.flutter.dev/docs/migration

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
