### PR TITLE
support file v6

### DIFF
--- a/flutter_cache_manager/pubspec.yaml
+++ b/flutter_cache_manager/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   sqflite: "^1.1.7+2"
   pedantic: "^1.8.0+1"
   clock: ^1.0.1
-  file: ^5.1.0
+  file: ">=5.1.0 <7.0.0"
   rxdart: '>=0.23.1 <0.25.0'
   
 dev_dependencies:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
flutter_driver in Flutter 1.22 depends on File v6. This package only accepts v5, so pub get fails.

### :new: What is the new behavior (if this is a feature change)?
Support both v5 and v6.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #216
Fix lik #218 but backwards compatible.

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
