### PR TITLE
Improve docs and variable naming

### DIFF
--- a/flutter_cache_manager/README.md
+++ b/flutter_cache_manager/README.md
@@ -64,13 +64,38 @@ class CustomCacheManager {
   );
 }
 ```
+## Frequently Asked Questions
+- [How are the cache files stored?](#how-are-the-cache-files-stored)
+- [When are the cached files updated?](#when-are-the-cached-files-updated)
+- [When are cached files removed?](#when-are-cached-files-removed?)
 
-## How it works
+
+### How are the cache files stored?
 By default the cached files are stored in the temporary directory of the app. This means the OS can delete the files any time.
 
-Information about the files is stored in a database using sqflite. The file name of the database is the key of the cacheManager, that's why that has to be unique.
+Information about the files is stored in a database using sqflite on Android, iOS and macOs, or in a plain JSON file
+ on other platforms. The file name of the database is the key of the cacheManager, that's why that has to be unique.
 
-This cache information contains the end date till when the file is valid and the eTag to use with the http cache-control.
+### When are the cached files updated?
+A valid url response should contain a Cache-Control header. More info on the header can be found 
+[here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control), but in summary it says for how long
+the image can be expected to be up to date. It also contains an 'eTag' which can be used to check (after that time) 
+whether the file did change or if it is actually still valid.
+
+When a file is in the cache that is always directly returned when calling `getSingleFile` or `getFileStream`. 
+After that the information is check if the file is actually still valid. If the file is outdated according to the 
+Cache-Control headers the manager tries to update the file and store the new one in the cache. When you use 
+`getFileStream` this updated file will also be returned in the stream.
+
+### When are cached files removed?
+The files can be removed by the cache manager or by the operating system. By default the files are stored in a cache
+ folder, which is sometimes cleaned for example on Android with an app update.
+
+The cache manager uses 2 variables to determine when to delete a file, the `maxNrOfCacheObjects` and the `stalePeriod`.
+The cache knows when files have been used latest. When cleaning the cache (which happens continuously), the cache
+deletes files when there are too many, ordered by last use, and when files just haven't been used for longer than
+the stale period.
+
 
 ## Breaking changes in v2
 - There is no longer a need to extend on BaseCacheManager, you can directly call the constructor. The BaseCacheManager

--- a/flutter_cache_manager/README.md
+++ b/flutter_cache_manager/README.md
@@ -67,7 +67,7 @@ class CustomCacheManager {
 ## Frequently Asked Questions
 - [How are the cache files stored?](#how-are-the-cache-files-stored)
 - [When are the cached files updated?](#when-are-the-cached-files-updated)
-- [When are cached files removed?](#when-are-cached-files-removed?)
+- [When are cached files removed?](#when-are-cached-files-removed)
 
 
 ### How are the cache files stored?

--- a/flutter_cache_manager/lib/src/cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_manager.dart
@@ -20,27 +20,27 @@ import 'config/config.dart';
 ///Copyright (c) 2019 Rene Floor
 ///Released under MIT License.
 
-abstract class BaseCacheManager {
+class CacheManager {
   /// Creates a new instance of a cache manager. This can be used to retrieve
   /// files from the cache or download them online. The http headers are used
   /// for the maximum age of the files. The BaseCacheManager should only be
   /// used in singleton patterns.
   ///
   /// The [_cacheKey] is used for the sqlite database file and should be unique.
-  /// Files are removed when they haven't been used for longer than [maxAgeCacheObject]
+  /// Files are removed when they haven't been used for longer than [stalePeriod]
   /// or when this cache has grown too big. When the cache is larger than [maxNrOfCacheObjects]
   /// files the files that haven't been used longest will be removed.
   /// The [fileService] can be used to customize how files are downloaded. For example
   /// to edit the urls, add headers or use a proxy. You can also choose to supply
   /// a CacheStore or WebHelper directly if you want more customization.
-  BaseCacheManager(Config config) {
+  CacheManager(Config config) {
     _config = config;
     _store = CacheStore(config);
     _webHelper = WebHelper(_store, config.fileService);
   }
 
   @visibleForTesting
-  BaseCacheManager.custom(
+  CacheManager.custom(
     Config config, {
     CacheStore cacheStore,
     WebHelper webHelper,
@@ -224,4 +224,9 @@ abstract class BaseCacheManager {
 
   /// Removes all files from the cache
   Future<void> emptyCache() => _store.emptyCache();
+
+  /// Closes the cache database
+  Future<void> dispose() async {
+    await _config.repo.close();
+  }
 }

--- a/flutter_cache_manager/lib/src/cache_managers/default_cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_managers/default_cache_manager.dart
@@ -4,7 +4,7 @@ import '../config/config.dart';
 /// The DefaultCacheManager that can be easily used directly. The code of
 /// this implementation can be used as inspiration for more complex cache
 /// managers.
-class DefaultCacheManager extends BaseCacheManager {
+class DefaultCacheManager extends CacheManager {
   static const key = 'libCachedImageData';
 
   static DefaultCacheManager _instance;

--- a/flutter_cache_manager/lib/src/cache_store.dart
+++ b/flutter_cache_manager/lib/src/cache_store.dart
@@ -24,7 +24,7 @@ class CacheStore {
   String get storeKey => _config.cacheKey;
   Future<CacheInfoRepository> _cacheInfoRepository;
   int get _capacity => _config.maxNrOfCacheObjects;
-  Duration get _maxAge => _config.maxAgeCacheObject;
+  Duration get _maxAge => _config.stalePeriod;
 
   DateTime lastCleanupRun = DateTime.now();
   Timer _scheduledCleanup;

--- a/flutter_cache_manager/lib/src/config/_config_io.dart
+++ b/flutter_cache_manager/lib/src/config/_config_io.dart
@@ -12,12 +12,12 @@ import 'config.dart' as def;
 class Config implements def.Config {
   Config(
     this.cacheKey, {
-    Duration maxAgeCacheObject,
+    Duration stalePeriod,
     int maxNrOfCacheObjects,
     CacheInfoRepository repo,
     FileSystem fileSystem,
     FileService fileService,
-  })  : maxAgeCacheObject = maxAgeCacheObject ?? const Duration(days: 30),
+  })  : stalePeriod = stalePeriod ?? const Duration(days: 30),
         maxNrOfCacheObjects = maxNrOfCacheObjects ?? 200,
         repo = repo ?? _createRepo(cacheKey),
         fileSystem = fileSystem ?? IOFileSystem(cacheKey),
@@ -33,7 +33,7 @@ class Config implements def.Config {
   final String cacheKey;
 
   @override
-  final Duration maxAgeCacheObject;
+  final Duration stalePeriod;
 
   @override
   final int maxNrOfCacheObjects;

--- a/flutter_cache_manager/lib/src/config/_config_unsupported.dart
+++ b/flutter_cache_manager/lib/src/config/_config_unsupported.dart
@@ -8,7 +8,7 @@ class Config implements def.Config {
   //ignore: avoid_unused_constructor_parameters
   Config(String cacheKey, {
     //ignore: avoid_unused_constructor_parameters
-    Duration maxAgeCacheObject,
+    Duration stalePeriod,
     //ignore: avoid_unused_constructor_parameters
     int maxNrOfCacheObjects,
     //ignore: avoid_unused_constructor_parameters
@@ -31,7 +31,7 @@ class Config implements def.Config {
   String get cacheKey => throw UnimplementedError();
 
   @override
-  Duration get maxAgeCacheObject => throw UnimplementedError();
+  Duration get stalePeriod => throw UnimplementedError();
 
   @override
   int get maxNrOfCacheObjects => throw UnimplementedError();

--- a/flutter_cache_manager/lib/src/config/_config_web.dart
+++ b/flutter_cache_manager/lib/src/config/_config_web.dart
@@ -9,12 +9,12 @@ import 'config.dart' as def;
 class Config implements def.Config {
   Config(
     this.cacheKey, {
-    Duration maxAgeCacheObject,
+    Duration stalePeriod,
     int maxNrOfCacheObjects,
     CacheInfoRepository repo,
     FileSystem fileSystem,
     FileService fileService,
-  })  : maxAgeCacheObject = maxAgeCacheObject ?? const Duration(days: 30),
+  })  : stalePeriod = stalePeriod ?? const Duration(days: 30),
         maxNrOfCacheObjects = maxNrOfCacheObjects ?? 200,
         repo = repo ?? NonStoringObjectProvider(),
         fileSystem = fileSystem ?? MemoryCacheSystem(),
@@ -30,7 +30,7 @@ class Config implements def.Config {
   final String cacheKey;
 
   @override
-  final Duration maxAgeCacheObject;
+  final Duration stalePeriod;
 
   @override
   final int maxNrOfCacheObjects;

--- a/flutter_cache_manager/lib/src/config/config.dart
+++ b/flutter_cache_manager/lib/src/config/config.dart
@@ -6,18 +6,35 @@ import '_config_unsupported.dart'
     if (dart.library.html) '_config_web.dart'
     if (dart.library.io) '_config_io.dart' as impl;
 
+
 abstract class Config {
+  /// Config file for the CacheManager.
+  /// [cacheKey] is used for the folder to store files and for the database
+  /// file name.
+  /// [stalePeriod] is the time duration in which a cache object is
+  /// considered 'stale'. When a file is cached but not being used for a
+  /// certain time the file will be deleted.
+  /// [maxNrOfCacheObjects] defines how large the cache is allowed to be. If
+  /// there are more files the files that haven't been used for the longest
+  /// time will be removed.
+  /// [repo] is the [CacheInfoRepository] which stores the cache metadata. On
+  /// Android, iOS and macOS this defaults to [CacheObjectProvider], a
+  /// sqflite implementation due to legacy. On web this defaults to
+  /// [NonStoringObjectProvider]. On the other platforms this defaults to
+  /// [JsonCacheInfoRepository].
+  /// The [fileSystem] defines where the cached files are stored and the
+  /// [fileService] defines where files are fetched, for example online.
   factory Config(
-      String cacheKey, {
-      Duration maxAgeCacheObject,
-      int maxNrOfCacheObjects,
+    String cacheKey, {
+    Duration stalePeriod,
+    int maxNrOfCacheObjects,
     CacheInfoRepository repo,
     FileSystem fileSystem,
-        FileService fileService,
+    FileService fileService,
   }) = impl.Config;
 
   String get cacheKey;
-  Duration get maxAgeCacheObject;
+  Duration get stalePeriod;
   int get maxNrOfCacheObjects;
   CacheInfoRepository get repo;
   FileSystem get fileSystem;

--- a/flutter_cache_manager/test/cache_manager_test.dart
+++ b/flutter_cache_manager/test/cache_manager_test.dart
@@ -440,7 +440,7 @@ void main() {
   });
 }
 
-class TestCacheManager extends BaseCacheManager {
+class TestCacheManager extends CacheManager {
   TestCacheManager(
     Config config, {
     CacheStore store,

--- a/flutter_cache_manager_firebase/lib/src/firebase_cache_manager.dart
+++ b/flutter_cache_manager_firebase/lib/src/firebase_cache_manager.dart
@@ -1,12 +1,10 @@
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 
 import 'firebase_http_file_service.dart';
-import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
 
 /// Use [FirebaseCacheManager] if you want to download files from firebase storage
 /// and store them in your local cache.
-class FirebaseCacheManager extends BaseCacheManager {
+class FirebaseCacheManager extends CacheManager {
   static const key = 'firebaseCache';
 
   static FirebaseCacheManager _instance;
@@ -16,11 +14,6 @@ class FirebaseCacheManager extends BaseCacheManager {
     return _instance;
   }
 
-  FirebaseCacheManager._() : super(key, fileService: FirebaseHttpFileService());
-
-  @override
-  Future<String> getFilePath() async {
-    var directory = await getTemporaryDirectory();
-    return p.join(directory.path, key);
-  }
+  FirebaseCacheManager._()
+      : super(Config(key, fileService: FirebaseHttpFileService()));
 }

--- a/flutter_cache_manager_firebase/pubspec.yaml
+++ b/flutter_cache_manager_firebase/pubspec.yaml
@@ -9,7 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_cache_manager: ^1.0.0
+  flutter_cache_manager:
+    path: ../flutter_cache_manager
   firebase_storage: '>=3.0.0 <5.0.0'
   path_provider: "^1.4.0"
   path: "^1.6.4"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Docs update

### :arrow_heading_down: What is the current behavior?
Docs don't mention the breaking changes. Docs are also not clear about when caches are cleared.

### :new: What is the new behavior (if this is a feature change)?
The readme has a part about the breaking changes.
The config class has documentation about when a cache becomes 'stale'.
The variable name of maxAge is changed to 'stalePeriod' as an old file is not deleted if it is still used.

### :boom: Does this PR introduce a breaking change?
Yes, maxAgeObject changed names, but it was already a breaking change in the config file, so it is not really useful to add a deprecated variable.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #139
Fixes #106

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
