### PR TITLE
Added option to migrate between repos

### DIFF
--- a/flutter_cache_manager/lib/src/storage/cache_info_repositories/cache_info_repository.dart
+++ b/flutter_cache_manager/lib/src/storage/cache_info_repositories/cache_info_repository.dart
@@ -56,13 +56,13 @@ extension MigrationExtension on CacheInfoRepository {
 
     await previousRepository.open();
     var cacheObjects = await previousRepository.getAllObjects();
-    await putAll(cacheObjects);
+    await _putAll(cacheObjects);
     var isClosed = await previousRepository.close();
     if(!isClosed) print('Deleting an open repository while migrating.');
     await previousRepository.deleteDataFile();
   }
 
-  Future<List<CacheObject>> putAll(List<CacheObject> cacheObjects) async {
+  Future<List<CacheObject>> _putAll(List<CacheObject> cacheObjects) async {
     var storedObjects = <CacheObject>[];
     for (var newObject in cacheObjects) {
       var existingObject = await get(newObject.key);

--- a/flutter_cache_manager/lib/src/storage/cache_info_repositories/cache_info_repository.dart
+++ b/flutter_cache_manager/lib/src/storage/cache_info_repositories/cache_info_repository.dart
@@ -4,14 +4,18 @@ import 'package:flutter_cache_manager/src/storage/cache_object.dart';
 
 /// Base class for cache info repositories
 abstract class CacheInfoRepository {
-  /// Opens the repository
-  Future open();
+  /// Returns whether or not there is an existing data file with cache info.
+  Future<bool> exists();
+
+  /// Opens the repository, or just returns true if the repo is already open.
+  Future<bool> open();
 
   /// Updates a given [CacheObject], if it exists, or adds a new item to the repository
   Future<dynamic> updateOrInsert(CacheObject cacheObject);
 
   /// Inserts [cacheObject] into the repository
-  Future<CacheObject> insert(CacheObject cacheObject);
+  Future<CacheObject> insert(CacheObject cacheObject,
+      {bool setTouchedToNow = true});
 
   /// Gets a [CacheObject] by [key]
   Future<CacheObject> get(String key);
@@ -23,7 +27,7 @@ abstract class CacheInfoRepository {
   Future<int> deleteAll(Iterable<int> ids);
 
   /// Updates an existing [cacheObject]
-  Future<int> update(CacheObject cacheObject);
+  Future<int> update(CacheObject cacheObject, {bool setTouchedToNow = true});
 
   /// Gets the list of all objects in the cache
   Future<List<CacheObject>> getAllObjects();
@@ -37,6 +41,43 @@ abstract class CacheInfoRepository {
   /// Returns a list of [CacheObject] that are older than [maxAge]
   Future<List<CacheObject>> getOldObjects(Duration maxAge);
 
-  /// Close the connection to the repository
-  Future close();
+  /// Close the connection to the repository. If this is the last connection
+  /// to the repository it will return true and the repository is trully
+  /// closed. If there are still open connections it will return false;
+  Future<bool> close();
+
+  /// Deletes the cache data file including all cache data.
+  Future<void> deleteDataFile();
+}
+
+extension MigrationExtension on CacheInfoRepository {
+  Future<void> migrateFrom(CacheInfoRepository previousRepository) async {
+    if (!await previousRepository.exists()) return;
+
+    await previousRepository.open();
+    var cacheObjects = await previousRepository.getAllObjects();
+    await putAll(cacheObjects);
+    var isClosed = await previousRepository.close();
+    if(!isClosed) print('Deleting an open repository while migrating.');
+    await previousRepository.deleteDataFile();
+  }
+
+  Future<List<CacheObject>> putAll(List<CacheObject> cacheObjects) async {
+    var storedObjects = <CacheObject>[];
+    for (var newObject in cacheObjects) {
+      var existingObject = await get(newObject.key);
+      CacheObject storedObject;
+      if (existingObject == null) {
+        storedObject = await insert(
+          newObject.copyWith(id: null),
+          setTouchedToNow: false,
+        );
+      } else {
+        var storedObject = newObject.copyWith(id: existingObject.id);
+        await update(storedObject, setTouchedToNow: false);
+      }
+      storedObjects.add(storedObject);
+    }
+    return storedObjects;
+  }
 }

--- a/flutter_cache_manager/lib/src/storage/cache_info_repositories/helper_methods.dart
+++ b/flutter_cache_manager/lib/src/storage/cache_info_repositories/helper_methods.dart
@@ -1,0 +1,28 @@
+import 'dart:async';
+
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+
+mixin CacheInfoRepositoryHelperMethods on CacheInfoRepository {
+
+  var openConnections = 0;
+  Completer<bool> openCompleter;
+
+  bool shouldOpenOnNewConnection(){
+    openConnections++;
+    openCompleter ??= Completer<bool>();
+    return openConnections == 1;
+  }
+
+  bool opened(){
+    openCompleter.complete(true);
+    return true;
+  }
+
+  bool shouldClose(){
+    openConnections--;
+    if(openConnections == 0){
+      openCompleter = null;
+    }
+    return openConnections == 0;
+  }
+}

--- a/flutter_cache_manager/lib/src/storage/cache_info_repositories/non_storing_object_provider.dart
+++ b/flutter_cache_manager/lib/src/storage/cache_info_repositories/non_storing_object_provider.dart
@@ -4,8 +4,8 @@ import 'cache_info_repository.dart';
 
 class NonStoringObjectProvider implements CacheInfoRepository {
   @override
-  Future close() {
-    return Future.value();
+  Future<bool> close() async {
+    return true;
   }
 
   @override
@@ -39,22 +39,38 @@ class NonStoringObjectProvider implements CacheInfoRepository {
   }
 
   @override
-  Future<CacheObject> insert(CacheObject cacheObject) {
+  Future<CacheObject> insert(
+    CacheObject cacheObject, {
+    bool setTouchedToNow = true,
+  }) {
     return Future.value(cacheObject);
   }
 
   @override
-  Future open() {
-    return Future.value();
+  Future<bool> open() async {
+    return true;
   }
 
   @override
-  Future<int> update(CacheObject cacheObject) {
+  Future<int> update(
+    CacheObject cacheObject, {
+    bool setTouchedToNow = true,
+  }) {
     return Future.value(0);
   }
 
   @override
   Future updateOrInsert(CacheObject cacheObject) {
     return Future.value();
+  }
+
+  @override
+  Future<void> deleteDataFile() async {
+    return;
+  }
+
+  @override
+  Future<bool> exists() async {
+    return false;
   }
 }

--- a/flutter_cache_manager/test/helpers/json_repo_helpers.dart
+++ b/flutter_cache_manager/test/helpers/json_repo_helpers.dart
@@ -1,0 +1,75 @@
+
+import 'dart:convert';
+
+import 'package:clock/clock.dart';
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_cache_manager/src/storage/cache_object.dart';
+
+const String databaseName = 'test';
+const String path =
+    '/data/user/0/com.example.example/databases/$databaseName.json';
+final directory = MemoryFileSystem().directory('database');
+const String testurl = 'www.baseflow.com/test.png';
+const String testurl2 = 'www.baseflow.com/test2.png';
+const String testurl3 = 'www.baseflow.com/test3.png';
+const String testurl4 = 'www.baseflow.com/test4.png';
+
+class JsonRepoHelpers {
+  static Future<JsonCacheInfoRepository> createRepository({bool open = true})
+  async {
+    var directory = await _createDirectory();
+    var file = await _createFile(directory);
+    var repository = JsonCacheInfoRepository.withFile(file);
+    if(open) await repository.open();
+    return repository;
+  }
+
+  static Future<Directory> _createDirectory() async {
+    var testDir =
+    await MemoryFileSystem().systemTempDirectory.createTemp('testFolder');
+    await testDir.create(recursive: true);
+    return testDir;
+  }
+
+  static Future<File> _createFile(Directory dir) {
+    var file = dir.childFile('$databaseName.json');
+    var json = jsonEncode(_createCacheObjects());
+    return file.writeAsString(json);
+  }
+
+  static List<Map<String, dynamic>> _createCacheObjects() {
+    return startCacheObjects
+        .map((e) => e.toMap(setTouchedToNow: false))
+        .toList();
+  }
+
+  static final List<CacheObject> startCacheObjects = [
+    // Old object
+    CacheObject(
+      testurl,
+      key: testurl,
+      id: 1,
+      touched: clock.now().subtract(const Duration(days: 8)),
+    ),
+    // New object
+    CacheObject(
+      testurl2,
+      key: testurl2,
+      id: 2,
+      touched: clock.now(),
+    ),
+    // A less new object
+    CacheObject(
+      testurl3,
+      key: testurl3,
+      id: 3,
+      touched: clock.now().subtract(const Duration(minutes: 1)),
+    ),
+  ];
+  static final CacheObject extraCacheObject = CacheObject(
+    testurl4,
+    key: testurl4,
+  );
+}

--- a/flutter_cache_manager/test/repositories/json_file_repository_test.dart
+++ b/flutter_cache_manager/test/repositories/json_file_repository_test.dart
@@ -1,21 +1,11 @@
-import 'dart:convert';
 import 'dart:io' as io;
 
-import 'package:clock/clock.dart';
-import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_cache_manager/src/storage/cache_info_repositories/json_cache_info_repository.dart';
 import 'package:flutter_cache_manager/src/storage/cache_object.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-const String databaseName = 'test';
-const String path =
-    '/data/user/0/com.example.example/databases/$databaseName.json';
-final directory = MemoryFileSystem().directory('database');
-const String testurl = 'www.baseflow.com/test.png';
-const String testurl2 = 'www.baseflow.com/test2.png';
-const String testurl3 = 'www.baseflow.com/test3.png';
-const String testurl4 = 'www.baseflow.com/test4.png';
+import '../helpers/json_repo_helpers.dart';
+
 
 void main() {
   group('Create repository', () {
@@ -52,34 +42,70 @@ void main() {
     });
   });
 
-  group('Open repository', () {
+  group('Open and close repository', () {
     test('Open repository should not throw', () async {
       var repository = JsonCacheInfoRepository.withFile(io.File(path));
       await repository.open();
+    });
+
+    test('An open repository can be closed', () async {
+      var repository = await JsonRepoHelpers.createRepository();
+      var isClosed = await repository.close();
+      expect(isClosed, true);
+    });
+
+    test('Opening twice should close after second close', () async {
+      var repository = await JsonRepoHelpers.createRepository();
+      await repository.open();
+      var isClosed = await repository.close();
+      expect(isClosed, false);
+      isClosed = await repository.close();
+      expect(isClosed, true);
+    });
+  });
+
+  group('Exist and delete', (){
+    test('New repository does not exist', () async {
+      var repository = JsonCacheInfoRepository.withFile(io.File(path));
+      var exists = await repository.exists();
+      expect(exists, false);
+    });
+
+    test('Existing repository does exists', () async {
+      var repository = await JsonRepoHelpers.createRepository();
+      var exists = await repository.exists();
+      expect(exists, true);
+    });
+
+    test('Deleted repository does not exists', () async {
+      var repository = await JsonRepoHelpers.createRepository();
+      await repository.deleteDataFile();
+      var exists = await repository.exists();
+      expect(exists, false);
     });
   });
 
   group('Get', () {
     test('Existing key should return', () async {
-      var repo = await Helpers.createRepository();
+      var repo = await JsonRepoHelpers.createRepository();
       var result = await repo.get(testurl);
       expect(result, isNotNull);
     });
 
     test('Non-existing key should return null', () async {
-      var repo = await Helpers.createRepository();
+      var repo = await JsonRepoHelpers.createRepository();
       var result = await repo.get('not an url');
       expect(result, isNull);
     });
 
     test('getAllObjects should return all objects', () async {
-      var repo = await Helpers.createRepository();
+      var repo = await JsonRepoHelpers.createRepository();
       var result = await repo.getAllObjects();
-      expect(result.length, Helpers.startCacheObjects.length);
+      expect(result.length, JsonRepoHelpers.startCacheObjects.length);
     });
 
     test('getObjectsOverCapacity should return oldest objects', () async {
-      var repo = await Helpers.createRepository();
+      var repo = await JsonRepoHelpers.createRepository();
       var result = await repo.getObjectsOverCapacity(1);
       expect(result.length, 2);
       expectIdInList(result, 1);
@@ -87,7 +113,7 @@ void main() {
     });
 
     test('getOldObjects should return only old objects', () async {
-      var repo = await Helpers.createRepository();
+      var repo = await JsonRepoHelpers.createRepository();
       var result = await repo.getOldObjects(const Duration(days: 7));
       expect(result.length, 1);
     });
@@ -95,10 +121,10 @@ void main() {
 
   group('update and insert', () {
     test('insert adds new object', () async {
-      var repo = await Helpers.createRepository();
-      var objectToInsert = Helpers.extraCacheObject;
-      var insertedObject = await repo.insert(Helpers.extraCacheObject);
-      expect(insertedObject.id, Helpers.startCacheObjects.length + 1);
+      var repo = await JsonRepoHelpers.createRepository();
+      var objectToInsert = JsonRepoHelpers.extraCacheObject;
+      var insertedObject = await repo.insert(JsonRepoHelpers.extraCacheObject);
+      expect(insertedObject.id, JsonRepoHelpers.startCacheObjects.length + 1);
       expect(insertedObject.url, objectToInsert.url);
       expect(insertedObject.touched, isNotNull);
 
@@ -109,14 +135,14 @@ void main() {
     });
 
     test('insert throws when adding existing object', () async {
-      var repo = await Helpers.createRepository();
-      var objectToInsert = Helpers.startCacheObjects.first;
+      var repo = await JsonRepoHelpers.createRepository();
+      var objectToInsert = JsonRepoHelpers.startCacheObjects.first;
       expect(() => repo.insert(objectToInsert), throwsArgumentError);
     });
 
     test('update changes existing item', () async {
-      var repo = await Helpers.createRepository();
-      var objectToInsert = Helpers.startCacheObjects.first;
+      var repo = await JsonRepoHelpers.createRepository();
+      var objectToInsert = JsonRepoHelpers.startCacheObjects.first;
       var newUrl = 'newUrl.com';
       var updatedObject = objectToInsert.copyWith(url: newUrl);
       await repo.update(updatedObject);
@@ -125,14 +151,14 @@ void main() {
     });
 
     test('update throws when adding new object', () async {
-      var repo = await Helpers.createRepository();
-      var newObject = Helpers.extraCacheObject;
+      var repo = await JsonRepoHelpers.createRepository();
+      var newObject = JsonRepoHelpers.extraCacheObject;
       expect(() => repo.update(newObject), throwsArgumentError);
     });
 
     test('updateOrInsert updates existing item', () async {
-      var repo = await Helpers.createRepository();
-      var objectToInsert = Helpers.startCacheObjects.first;
+      var repo = await JsonRepoHelpers.createRepository();
+      var objectToInsert = JsonRepoHelpers.startCacheObjects.first;
       var newUrl = 'newUrl.com';
       var updatedObject = objectToInsert.copyWith(url: newUrl);
       await repo.updateOrInsert(updatedObject);
@@ -141,10 +167,10 @@ void main() {
     });
 
     test('updateOrInsert inserts new item', () async {
-      var repo = await Helpers.createRepository();
-      var objectToInsert = Helpers.extraCacheObject;
-      var insertedObject = await repo.updateOrInsert(Helpers.extraCacheObject);
-      expect(insertedObject.id, Helpers.startCacheObjects.length + 1);
+      var repo = await JsonRepoHelpers.createRepository();
+      var objectToInsert = JsonRepoHelpers.extraCacheObject;
+      var insertedObject = await repo.updateOrInsert(JsonRepoHelpers.extraCacheObject);
+      expect(insertedObject.id, JsonRepoHelpers.startCacheObjects.length + 1);
       expect(insertedObject.url, objectToInsert.url);
       expect(insertedObject.touched, isNotNull);
 
@@ -158,18 +184,18 @@ void main() {
   group('delete', () {
     test('delete removes item', () async {
       var removedId = 2;
-      var repo = await Helpers.createRepository();
+      var repo = await JsonRepoHelpers.createRepository();
       var deleted = await repo.delete(removedId);
       expect(deleted, 1);
       var objects = await repo.getAllObjects();
       var removedObject = objects.where((element) => element.id == removedId);
       expect(removedObject.length, 0);
-      expect(objects.length, Helpers.startCacheObjects.length - 1);
+      expect(objects.length, JsonRepoHelpers.startCacheObjects.length - 1);
     });
 
     test('deleteAll removes all items', () async {
       var removedIds = [2, 3];
-      var repo = await Helpers.createRepository();
+      var repo = await JsonRepoHelpers.createRepository();
       var deleted = await repo.deleteAll(removedIds);
       expect(deleted, 2);
       var objects = await repo.getAllObjects();
@@ -177,12 +203,12 @@ void main() {
           objects.where((element) => removedIds.contains(element.id));
       expect(removedObject.length, 0);
       expect(
-          objects.length, Helpers.startCacheObjects.length - removedIds.length);
+          objects.length, JsonRepoHelpers.startCacheObjects.length - removedIds.length);
     });
 
     test('delete does not remove non-existing items', () async {
       var removedId = 99;
-      var repo = await Helpers.createRepository();
+      var repo = await JsonRepoHelpers.createRepository();
       var deleted = await repo.delete(removedId);
       expect(deleted, 0);
     });
@@ -191,16 +217,16 @@ void main() {
 
   group('storage', (){
     test('Changes should be persisted', () async {
-      var repo = await Helpers.createRepository();
-      await repo.insert(Helpers.extraCacheObject);
+      var repo = await JsonRepoHelpers.createRepository();
+      await repo.insert(JsonRepoHelpers.extraCacheObject);
       var allObjects = await repo.getAllObjects();
-      expect(allObjects.length, Helpers.startCacheObjects.length + 1);
+      expect(allObjects.length, JsonRepoHelpers.startCacheObjects.length + 1);
 
       await repo.close();
       await repo.open();
 
       var allObjectsAfterOpen = await repo.getAllObjects();
-      expect(allObjectsAfterOpen.length, Helpers.startCacheObjects.length + 1);
+      expect(allObjectsAfterOpen.length, JsonRepoHelpers.startCacheObjects.length + 1);
 
     });
   });
@@ -210,61 +236,4 @@ void expectIdInList(List<CacheObject> cacheObjects, int id) {
   var object = cacheObjects.singleWhere((element) => element.id == id,
       orElse: () => null);
   expect(object, isNotNull);
-}
-
-class Helpers {
-  static Future<JsonCacheInfoRepository> createRepository() async {
-    var directory = await _createDirectory();
-    var file = await _createFile(directory);
-    var repository = JsonCacheInfoRepository.withFile(file);
-    await repository.open();
-    return repository;
-  }
-
-  static Future<Directory> _createDirectory() async {
-    var testDir =
-        await MemoryFileSystem().systemTempDirectory.createTemp('testFolder');
-    await testDir.create(recursive: true);
-    return testDir;
-  }
-
-  static Future<File> _createFile(Directory dir) {
-    var file = dir.childFile('$databaseName.json');
-    var json = jsonEncode(_createCacheObjects());
-    return file.writeAsString(json);
-  }
-
-  static List<Map<String, dynamic>> _createCacheObjects() {
-    return startCacheObjects
-        .map((e) => e.toMap(setTouchedToNow: false))
-        .toList();
-  }
-
-  static final List<CacheObject> startCacheObjects = [
-    // Old object
-    CacheObject(
-      testurl,
-      key: testurl,
-      id: 1,
-      touched: clock.now().subtract(const Duration(days: 8)),
-    ),
-    // New object
-    CacheObject(
-      testurl2,
-      key: testurl2,
-      id: 2,
-      touched: clock.now(),
-    ),
-    // A less new object
-    CacheObject(
-      testurl3,
-      key: testurl3,
-      id: 3,
-      touched: clock.now().subtract(const Duration(minutes: 1)),
-    ),
-  ];
-  static final CacheObject extraCacheObject = CacheObject(
-    testurl4,
-    key: testurl4,
-  );
 }

--- a/flutter_cache_manager/test/repositories/migration_test.dart
+++ b/flutter_cache_manager/test/repositories/migration_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_cache_manager/src/storage/cache_object.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../helpers/json_repo_helpers.dart' show JsonRepoHelpers;
+import '../helpers/mock_cache_info_repository.dart';
+
+void main() {
+  group('Migration tests', () {
+    test('Files are added in new repo', () async {
+      var mockRepo = setupMockRepo(false);
+      var source = await JsonRepoHelpers.createRepository(open: false);
+      await mockRepo.migrateFrom(source);
+      for (var object in JsonRepoHelpers.startCacheObjects) {
+        verify(
+          mockRepo.insert(
+            argThat(CacheObjectMatcher(object)),
+            setTouchedToNow: anyNamed('setTouchedToNow'),
+          ),
+        );
+      }
+    });
+
+    test('Old repo is deleted', () async {
+      var mockRepo = setupMockRepo(false);
+      var source = await JsonRepoHelpers.createRepository(open: false);
+      await mockRepo.migrateFrom(source);
+      var exists = await source.exists();
+      expect(exists, false);
+    });
+
+    test('Files are updated in an existing repo', () async {
+      var mockRepo = setupMockRepo(true);
+      var source = await JsonRepoHelpers.createRepository(open: false);
+      await mockRepo.migrateFrom(source);
+      for (var object in JsonRepoHelpers.startCacheObjects) {
+        verify(
+          mockRepo.update(
+            argThat(CacheObjectMatcher(object)),
+            setTouchedToNow: anyNamed('setTouchedToNow'),
+          ),
+        );
+      }
+    });
+  });
+}
+
+MockCacheInfoRepository setupMockRepo(bool returnObjects) {
+  var mockRepo = MockCacheInfoRepository();
+  when(mockRepo.get(any)).thenAnswer((realInvocation) {
+    if (!returnObjects) return null;
+    var key = realInvocation.positionalArguments.first as String;
+    var cacheObject = JsonRepoHelpers.startCacheObjects.firstWhere(
+      (element) => element.key == key,
+      orElse: () => null,
+    );
+    return Future.value(cacheObject);
+  });
+  when(mockRepo.insert(any)).thenAnswer((realInvocation) =>
+      Future.value(realInvocation.positionalArguments.first as CacheObject));
+  return mockRepo;
+}
+
+class CacheObjectMatcher extends Matcher {
+  final CacheObject value;
+  static final Object _mismatchedValueKey = Object();
+
+  CacheObjectMatcher(this.value);
+
+  @override
+  Description describe(Description description) {
+    description.add('Matches cacheObject $value');
+  }
+
+  @override
+  bool matches(item, Map matchState) {
+    var isMatch = false;
+    if (item is CacheObject) {
+      isMatch = item.key == value.key &&
+          item.url == value.url &&
+          item.relativePath == value.relativePath &&
+          item.length == value.length &&
+          item.touched.millisecondsSinceEpoch ==
+              value.touched.millisecondsSinceEpoch &&
+          item.eTag == value.eTag;
+    }
+    if (!isMatch) matchState[_mismatchedValueKey] = item;
+    return isMatch;
+  }
+
+  @override
+  Description describeMismatch(
+    dynamic item,
+    Description mismatchDescription,
+    Map<dynamic, dynamic> matchState,
+    bool verbose,
+  ) {
+    if (matchState.containsKey(_mismatchedValueKey)) {
+      final actualValue = matchState[_mismatchedValueKey] as CacheObject;
+      // Leading whitespace is added so that lines in the multiline
+      // description returned by addDescriptionOf are all indented equally
+      // which makes the output easier to read for this case.
+      return mismatchDescription
+          .add('expected normalized value\n  ')
+          .addDescriptionOf('${value.key}: ${value.url}')
+          .add('\nbut got\n  ')
+          .addDescriptionOf('${actualValue.key}: ${actualValue.url}');
+    }
+    return mismatchDescription;
+  }
+}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
There is no easy way to migrate to newer CacheInfoRepositories

### :new: What is the new behavior (if this is a feature change)?
- Adds a method to migrate.
- Adds methods to the CacheInfoRepositories to make this possible.
- Changes the behaviour of open/close to allow for multiple connections.

### :boom: Does this PR introduce a breaking change?
Yes, other implementations of CacheInfoRepository will need to change.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
