### PR TITLE
Avoid calling getDownloadURL in favor of directly getting data

### DIFF
--- a/flutter_cache_manager/example/lib/generated_plugin_registrant.dart
+++ b/flutter_cache_manager/example/lib/generated_plugin_registrant.dart
@@ -2,15 +2,12 @@
 // Generated file. Do not edit.
 //
 
-// ignore: unused_import
-import 'dart:ui';
-
 import 'package:url_launcher_web/url_launcher_web.dart';
 
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
 // ignore: public_member_api_docs
-void registerPlugins(PluginRegistry registry) {
-  UrlLauncherPlugin.registerWith(registry.registrarFor(UrlLauncherPlugin));
-  registry.registerMessageHandler();
+void registerPlugins(Registrar registrar) {
+  UrlLauncherPlugin.registerWith(registrar);
+  registrar.registerMessageHandler();
 }

--- a/flutter_cache_manager_firebase/CHANGELOG.md
+++ b/flutter_cache_manager_firebase/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.1.1-beta] - 2020-10-21
+* Replace getDownloadURL with getData to avoid token creation
+
 ## [1.1.0-beta] - 2020-10-02
 * Update CacheManager dependency to 2.x.x.
 

--- a/flutter_cache_manager_firebase/lib/src/firebase_http_file_service.dart
+++ b/flutter_cache_manager_firebase/lib/src/firebase_http_file_service.dart
@@ -13,16 +13,19 @@ class FirebaseHttpFileService extends HttpFileService {
       {Map<String, String> headers = const {}}) async {
     final ref = await FirebaseStorage.instance.getReferenceFromUrl(url);
     final metaData = await ref.getMetadata();
+    final headers = {
+      HttpHeaders.contentTypeHeader: metaData.contentType,
+      HttpHeaders.contentLanguageHeader: metaData.contentLanguage,
+      HttpHeaders.dateHeader: metaData.creationTimeMillis.toString(),
+      HttpHeaders.contentLocationHeader: metaData.path,
+    };
+    if (metaData.cacheControl != null) {
+      headers[HttpHeaders.cacheControlHeader] = metaData.cacheControl;
+    }
     final response = http.StreamedResponse(
       ref.getData(metaData.sizeBytes).asStream(),
       200,
-      headers: {
-        HttpHeaders.contentTypeHeader: metaData.contentType,
-        HttpHeaders.cacheControlHeader: metaData.cacheControl,
-        HttpHeaders.contentLanguageHeader: metaData.contentLanguage,
-        HttpHeaders.dateHeader: metaData.creationTimeMillis.toString(),
-        HttpHeaders.contentLocationHeader: metaData.path,
-      },
+      headers: headers,
     );
 
     return HttpGetResponse(response);

--- a/flutter_cache_manager_firebase/lib/src/firebase_http_file_service.dart
+++ b/flutter_cache_manager_firebase/lib/src/firebase_http_file_service.dart
@@ -11,19 +11,20 @@ class FirebaseHttpFileService extends HttpFileService {
   @override
   Future<FileServiceResponse> get(String url,
       {Map<String, String> headers = const {}}) async {
-    final ref = await FirebaseStorage.instance.getReferenceFromUrl(url);
+    final ref = FirebaseStorage.instance.refFromURL(url);
     final metaData = await ref.getMetadata();
     final headers = {
       HttpHeaders.contentTypeHeader: metaData.contentType,
       HttpHeaders.contentLanguageHeader: metaData.contentLanguage,
-      HttpHeaders.dateHeader: metaData.creationTimeMillis.toString(),
-      HttpHeaders.contentLocationHeader: metaData.path,
+      HttpHeaders.dateHeader:
+          metaData.timeCreated.millisecondsSinceEpoch.toString(),
+      HttpHeaders.contentLocationHeader: metaData.fullPath,
     };
     if (metaData.cacheControl != null) {
       headers[HttpHeaders.cacheControlHeader] = metaData.cacheControl;
     }
     final response = http.StreamedResponse(
-      ref.getData(metaData.sizeBytes).asStream(),
+      ref.getData(metaData.size).asStream(),
       200,
       headers: headers,
     );

--- a/flutter_cache_manager_firebase/lib/src/firebase_http_file_service.dart
+++ b/flutter_cache_manager_firebase/lib/src/firebase_http_file_service.dart
@@ -10,10 +10,16 @@ class FirebaseHttpFileService extends HttpFileService {
   Future<FileServiceResponse> get(String url,
       {Map<String, String> headers = const {}}) async {
     final ref = await FirebaseStorage.instance.getReferenceFromUrl(url);
-    final streamedResponse = http.StreamedResponse(
-        ref.getData(0x12FFFFFF).asStream(), 200,
-        headers: headers);
+    final metaData = await ref.getMetadata();
+    final response = http.StreamedResponse(
+      ref.getData(metaData.sizeBytes).asStream(),
+      200,
+      headers: {
+        'content-type': metaData.contentType,
+        'charset': metaData.contentEncoding,
+      },
+    );
 
-    return HttpGetResponse(streamedResponse);
+    return HttpGetResponse(response);
   }
 }

--- a/flutter_cache_manager_firebase/lib/src/firebase_http_file_service.dart
+++ b/flutter_cache_manager_firebase/lib/src/firebase_http_file_service.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:http/http.dart' as http;
@@ -15,8 +17,11 @@ class FirebaseHttpFileService extends HttpFileService {
       ref.getData(metaData.sizeBytes).asStream(),
       200,
       headers: {
-        'content-type': metaData.contentType,
-        'charset': metaData.contentEncoding,
+        HttpHeaders.contentTypeHeader: metaData.contentType,
+        HttpHeaders.cacheControlHeader: metaData.cacheControl,
+        HttpHeaders.contentLanguageHeader: metaData.contentLanguage,
+        HttpHeaders.dateHeader: metaData.creationTimeMillis.toString(),
+        HttpHeaders.contentLocationHeader: metaData.path,
       },
     );
 

--- a/flutter_cache_manager_firebase/lib/src/firebase_http_file_service.dart
+++ b/flutter_cache_manager_firebase/lib/src/firebase_http_file_service.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:http/http.dart' as http;
 
 /// [FirebaseHttpFileService] is another common file service which parses a
 /// firebase reference into, to standard url which can be passed to the
@@ -8,9 +9,11 @@ class FirebaseHttpFileService extends HttpFileService {
   @override
   Future<FileServiceResponse> get(String url,
       {Map<String, String> headers = const {}}) async {
-    var ref = FirebaseStorage.instance.ref().child(url);
-    var _url = await ref.getDownloadURL() as String;
+    final ref = await FirebaseStorage.instance.getReferenceFromUrl(url);
+    final streamedResponse = http.StreamedResponse(
+        ref.getData(0x12FFFFFF).asStream(), 200,
+        headers: headers);
 
-    return super.get(_url);
+    return HttpGetResponse(streamedResponse);
   }
 }

--- a/flutter_cache_manager_firebase/pubspec.yaml
+++ b/flutter_cache_manager_firebase/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_cache_manager: ^2.0.0-beta
-  firebase_storage: '>=5.0.0 <6.0.0'
+  firebase_storage: '>=5.0.0 <7.0.0'
   path_provider: "^1.4.0"
   path: "^1.6.4"
 

--- a/flutter_cache_manager_firebase/pubspec.yaml
+++ b/flutter_cache_manager_firebase/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_cache_manager: ^2.0.0-beta
-  firebase_storage: '>=3.0.0 <6.0.0'
+  firebase_storage: '>=5.0.0 <6.0.0'
   path_provider: "^1.4.0"
   path: "^1.6.4"
 

--- a/flutter_cache_manager_firebase/pubspec.yaml
+++ b/flutter_cache_manager_firebase/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_cache_manager_firebase
 description: CacheManager implementation for firebase_storage. Uses the gs:// as key and translates to https://
-version: 1.1.0-beta
+version: 1.1.1-beta
 homepage: https://github.com/Baseflow/flutter_cache_manager
 
 environment:

--- a/flutter_cache_manager_firebase/pubspec.yaml
+++ b/flutter_cache_manager_firebase/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_cache_manager: ^2.0.0-beta
-  firebase_storage: '>=5.0.0 <7.0.0'
+  firebase_storage: '>=5.0.0 <=7.0.0'
   path_provider: "^1.4.0"
   path: "^1.6.4"
 

--- a/flutter_cache_manager_firebase/pubspec.yaml
+++ b/flutter_cache_manager_firebase/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_cache_manager: ^2.0.0-beta
-  firebase_storage: '>=3.0.0 <5.0.0'
+  firebase_storage: '>=3.0.0 <6.0.0'
   path_provider: "^1.4.0"
   path: "^1.6.4"
 

--- a/flutter_cache_manager_firebase/pubspec.yaml
+++ b/flutter_cache_manager_firebase/pubspec.yaml
@@ -10,9 +10,9 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_cache_manager: ^2.0.0-beta
-  firebase_storage: '>=5.0.0 <=7.0.0'
-  path_provider: "^1.4.0"
-  path: "^1.6.4"
+  firebase_storage: ^7.0.0
+  path_provider: ^1.4.0
+  path: ^1.6.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This would handle #240. I'm scared this adds an extra network call (possibly two but I don't think `getReferenceFromUrl` is a network req) so I won't I expect anything from this PR and the simplicity of `getDownloadURL` might be preferred.

I think the original bug is that the the extension is not being carried through to the path in either my implementation or the current one and that's what's causing this line to fail in the original issue:

```dart
final file = await FirebaseCacheManager().getSingleFile(audioURL);
// returns a file with a path of local_path/foo_bar instead of local_path/foo_bar.mp3
```

### :boom: Does this PR introduce a breaking change?
No

### :memo: Links to relevant issues/docs
https://github.com/firebase/firebase-js-sdk/issues/76

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
