### PR TITLE
Rename Config to CacheConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ and a custom FileService. The key parameter in the constructor is mandatory, all
 class CustomCacheManager {
   static const key = 'customCacheKey';
   static CacheManager instance = CacheManager(
-    Config(
+    CacheConfig(
       key,
       stalePeriod: const Duration(days: 7),
       maxNrOfCacheObjects: 20,
@@ -104,3 +104,7 @@ the stale period.
 - The constructor now expects a Config object with some settings you were used to, but some are slightly different.
 For example the system where you want to store your files is not just a dictionary anymore, but a FileSystem. That way
 you have more freedom on where to store your files.
+
+
+## Breaking changes in v3
+- `Config` has been renamed to `CacheConfig` to avoid the need of library prefixes.

--- a/flutter_cache_manager/CHANGELOG.md
+++ b/flutter_cache_manager/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [3.0.0] - 2020-11-04
+- `Config` has been renamed to `CacheConfig` to avoid the need of library prefixes.
+
 ## [2.0.0] - 2020-10-16
 * Restructured the configuration of the CacheManager. Look at the ReadMe for more information.
 * Added queueing mechanism for downloading new files. By default, the cache manager downloads a maximum of 10 files

--- a/flutter_cache_manager/README.md
+++ b/flutter_cache_manager/README.md
@@ -53,7 +53,7 @@ and a custom FileService. The key parameter in the constructor is mandatory, all
 class CustomCacheManager {
   static const key = 'customCacheKey';
   static CacheManager instance = CacheManager(
-    Config(
+    CacheConfig(
       key,
       stalePeriod: const Duration(days: 7),
       maxNrOfCacheObjects: 20,
@@ -106,3 +106,7 @@ For example the system where you want to store your files is not just a dictiona
 you have more freedom on where to store your files.
 
 -  See the example in [Customize](#customize).
+
+
+## Breaking changes in v3
+- `Config` has been renamed to `CacheConfig` to avoid the need of library prefixes.

--- a/flutter_cache_manager/lib/src/cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_manager.dart
@@ -35,7 +35,7 @@ class CacheManager implements BaseCacheManager {
   /// The [fileService] can be used to customize how files are downloaded. For example
   /// to edit the urls, add headers or use a proxy. You can also choose to supply
   /// a CacheStore or WebHelper directly if you want more customization.
-  CacheManager(Config config) {
+  CacheManager(CacheConfig config) {
     _config = config;
     _store = CacheStore(config);
     _webHelper = WebHelper(_store, config.fileService);
@@ -43,7 +43,7 @@ class CacheManager implements BaseCacheManager {
 
   @visibleForTesting
   CacheManager.custom(
-    Config config, {
+    CacheConfig config, {
     CacheStore cacheStore,
     WebHelper webHelper,
   }) {
@@ -52,7 +52,7 @@ class CacheManager implements BaseCacheManager {
     _webHelper = webHelper ?? WebHelper(_store, config.fileService);
   }
 
-  Config _config;
+  CacheConfig _config;
 
   /// Store helper for cached files
   CacheStore _store;

--- a/flutter_cache_manager/lib/src/cache_managers/default_cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_managers/default_cache_manager.dart
@@ -13,5 +13,5 @@ class DefaultCacheManager extends CacheManager {
     return _instance;
   }
 
-  DefaultCacheManager._() : super(Config(key));
+  DefaultCacheManager._() : super(CacheConfig(key));
 }

--- a/flutter_cache_manager/lib/src/cache_store.dart
+++ b/flutter_cache_manager/lib/src/cache_store.dart
@@ -20,7 +20,7 @@ class CacheStore {
 
   FileSystem fileSystem;
 
-  final Config _config;
+  final CacheConfig _config;
   String get storeKey => _config.cacheKey;
   Future<CacheInfoRepository> _cacheInfoRepository;
   int get _capacity => _config.maxNrOfCacheObjects;
@@ -29,7 +29,7 @@ class CacheStore {
   DateTime lastCleanupRun = DateTime.now();
   Timer _scheduledCleanup;
 
-  CacheStore(Config config) : _config = config {
+  CacheStore(CacheConfig config) : _config = config {
     fileSystem = config.fileSystem;
     _cacheInfoRepository = config.repo.open().then((value) => config.repo);
   }

--- a/flutter_cache_manager/lib/src/config/_config_io.dart
+++ b/flutter_cache_manager/lib/src/config/_config_io.dart
@@ -9,7 +9,7 @@ import 'package:flutter_cache_manager/src/storage/file_system/file_system_io.dar
 
 import 'config.dart' as def;
 
-class Config implements def.Config {
+class Config implements def.CacheConfig {
   Config(
     this.cacheKey, {
     Duration stalePeriod,

--- a/flutter_cache_manager/lib/src/config/_config_io.dart
+++ b/flutter_cache_manager/lib/src/config/_config_io.dart
@@ -9,8 +9,8 @@ import 'package:flutter_cache_manager/src/storage/file_system/file_system_io.dar
 
 import 'config.dart' as def;
 
-class Config implements def.CacheConfig {
-  Config(
+class CacheConfig implements def.CacheConfig {
+  CacheConfig(
     this.cacheKey, {
     Duration stalePeriod,
     int maxNrOfCacheObjects,

--- a/flutter_cache_manager/lib/src/config/_config_unsupported.dart
+++ b/flutter_cache_manager/lib/src/config/_config_unsupported.dart
@@ -4,7 +4,7 @@ import 'package:flutter_cache_manager/src/web/file_service.dart';
 
 import 'config.dart' as def;
 
-class Config implements def.Config {
+class Config implements def.CacheConfig {
   //ignore: avoid_unused_constructor_parameters
   Config(
     //ignore: avoid_unused_constructor_parameters

--- a/flutter_cache_manager/lib/src/config/_config_unsupported.dart
+++ b/flutter_cache_manager/lib/src/config/_config_unsupported.dart
@@ -4,9 +4,9 @@ import 'package:flutter_cache_manager/src/web/file_service.dart';
 
 import 'config.dart' as def;
 
-class Config implements def.CacheConfig {
+class CacheConfig implements def.CacheConfig {
   //ignore: avoid_unused_constructor_parameters
-  Config(
+  CacheConfig(
     //ignore: avoid_unused_constructor_parameters
     String cacheKey, {
     //ignore: avoid_unused_constructor_parameters

--- a/flutter_cache_manager/lib/src/config/_config_web.dart
+++ b/flutter_cache_manager/lib/src/config/_config_web.dart
@@ -6,8 +6,8 @@ import 'package:flutter_cache_manager/src/web/file_service.dart';
 
 import 'config.dart' as def;
 
-class Config implements def.CacheConfig {
-  Config(
+class CacheConfig implements def.CacheConfig {
+  CacheConfig(
     this.cacheKey, {
     Duration stalePeriod,
     int maxNrOfCacheObjects,

--- a/flutter_cache_manager/lib/src/config/_config_web.dart
+++ b/flutter_cache_manager/lib/src/config/_config_web.dart
@@ -6,7 +6,7 @@ import 'package:flutter_cache_manager/src/web/file_service.dart';
 
 import 'config.dart' as def;
 
-class Config implements def.Config {
+class Config implements def.CacheConfig {
   Config(
     this.cacheKey, {
     Duration stalePeriod,

--- a/flutter_cache_manager/lib/src/config/config.dart
+++ b/flutter_cache_manager/lib/src/config/config.dart
@@ -30,7 +30,7 @@ abstract class CacheConfig {
     CacheInfoRepository repo,
     FileSystem fileSystem,
     FileService fileService,
-  }) = impl.Config;
+  }) = impl.CacheConfig;
 
   String get cacheKey;
   Duration get stalePeriod;

--- a/flutter_cache_manager/lib/src/config/config.dart
+++ b/flutter_cache_manager/lib/src/config/config.dart
@@ -6,7 +6,7 @@ import '_config_unsupported.dart'
     if (dart.library.html) '_config_web.dart'
     if (dart.library.io) '_config_io.dart' as impl;
 
-abstract class Config {
+abstract class CacheConfig {
   /// Config file for the CacheManager.
   /// [cacheKey] is used for the folder to store files and for the database
   /// file name.
@@ -23,7 +23,7 @@ abstract class Config {
   /// [JsonCacheInfoRepository].
   /// The [fileSystem] defines where the cached files are stored and the
   /// [fileService] defines where files are fetched, for example online.
-  factory Config(
+  factory CacheConfig(
     String cacheKey, {
     Duration stalePeriod,
     int maxNrOfCacheObjects,

--- a/flutter_cache_manager/pubspec.yaml
+++ b/flutter_cache_manager/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_cache_manager
 description: Generic cache manager for flutter. Saves web files on the storages of the device and saves the cache info using sqflite.
-version: 2.0.0
+version: 3.0.0
 homepage: https://github.com/Baseflow/flutter_cache_manager
 
 environment:

--- a/flutter_cache_manager/test/cache_manager_test.dart
+++ b/flutter_cache_manager/test/cache_manager_test.dart
@@ -22,7 +22,7 @@ void main() {
       var fileUrl = 'baseflow.com/test';
       var validTill = DateTime.now().add(const Duration(days: 1));
 
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       await config.returnsFile(fileName);
       config.returnsCacheObject(fileUrl, fileName, validTill);
 
@@ -37,7 +37,7 @@ void main() {
       var fileUrl = 'baseflow.com/test';
       var validTill = DateTime.now().subtract(const Duration(days: 1));
 
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       await config.returnsFile(fileName);
       config.returnsCacheObject(fileUrl, fileName, validTill);
 
@@ -52,7 +52,7 @@ void main() {
     test('Non-existing cacheFile should call to web', () async {
       var fileUrl = 'baseflow.com/test';
 
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       config.returnsNoCacheObject(fileUrl);
 
       var cacheManager = TestCacheManager(config);
@@ -65,7 +65,7 @@ void main() {
 
   group('Explicit key', () {
     test('Valid cacheFile should not call to web', () async {
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
 
       var fileName = 'test.jpg';
       var fileUrl = 'baseflow.com/test';
@@ -87,7 +87,7 @@ void main() {
       var fileKey = 'test1234';
       var validTill = DateTime.now().subtract(const Duration(days: 1));
 
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       config.returnsCacheObject(fileUrl, fileName, validTill, key: fileKey);
       await config.returnsFile(fileName);
 
@@ -105,7 +105,7 @@ void main() {
       var fileKey = 'test1234';
       var validTill = DateTime.now().subtract(const Duration(days: 1));
 
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       config.returnsCacheObject(fileUrl, fileName, validTill, key: fileKey);
 
       var cacheManager = TestCacheManager(config);
@@ -122,12 +122,12 @@ void main() {
       var fileUrl = 'baseflow.com/test';
       var validTill = DateTime.now().add(const Duration(days: 1));
 
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       config.returnsCacheObject(fileUrl, fileName, validTill);
       await config.returnsFile(fileName);
 
       var store = MockStore();
-      var file = await createTestConfig().fileSystem.createFile(fileName);
+      var file = await createTestCacheConfig().fileSystem.createFile(fileName);
       var fileInfo = FileInfo(file, FileSource.Cache, validTill, fileUrl);
       when(store.getFile(fileUrl)).thenAnswer((_) => Future.value(fileInfo));
 
@@ -145,7 +145,7 @@ void main() {
       var validTill = DateTime.now().subtract(const Duration(days: 1));
 
       var store = MockStore();
-      var file = await createTestConfig().fileSystem.createFile(fileName);
+      var file = await createTestCacheConfig().fileSystem.createFile(fileName);
       var cachedInfo = FileInfo(file, FileSource.Cache, validTill, fileUrl);
       when(store.getFile(fileUrl)).thenAnswer((_) => Future.value(cachedInfo));
 
@@ -155,7 +155,7 @@ void main() {
       when(webHelper.downloadFile(fileUrl, key: anyNamed('key')))
           .thenAnswer((_) => Stream.value(downloadedInfo));
 
-      var cacheManager = TestCacheManager(createTestConfig(),
+      var cacheManager = TestCacheManager(createTestCacheConfig(),
           store: store, webHelper: webHelper);
 
       // ignore: deprecated_member_use_from_same_package
@@ -171,7 +171,7 @@ void main() {
       var validTill = DateTime.now().subtract(const Duration(days: 1));
 
       var store = MockStore();
-      var file = await createTestConfig().fileSystem.createFile(fileName);
+      var file = await createTestCacheConfig().fileSystem.createFile(fileName);
       var fileInfo = FileInfo(file, FileSource.Cache, validTill, fileUrl);
 
       when(store.getFile(fileUrl)).thenAnswer((_) => Future.value(null));
@@ -181,7 +181,7 @@ void main() {
           .thenAnswer((_) => Stream.value(fileInfo));
 
       var cacheManager = TestCacheManager(
-        createTestConfig(),
+        createTestCacheConfig(),
         store: store,
         webHelper: webHelper,
       );
@@ -205,7 +205,7 @@ void main() {
           .thenThrow(error);
 
       var cacheManager = TestCacheManager(
-        createTestConfig(),
+        createTestCacheConfig(),
         store: store,
         webHelper: webHelper,
       );
@@ -223,7 +223,7 @@ void main() {
       var fileKey = 'test1234';
       var validTill = DateTime.now().add(const Duration(days: 1));
 
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       config.returnsCacheObject(fileUrl, fileName, validTill, key: fileKey);
       await config.returnsFile(fileName);
 
@@ -240,7 +240,7 @@ void main() {
       var fileKey = 'test1234';
       var validTill = DateTime.now().subtract(const Duration(days: 1));
 
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       config.returnsCacheObject(fileUrl, fileName, validTill, key: fileKey);
       await config.returnsFile(fileName);
 
@@ -257,7 +257,7 @@ void main() {
       var fileKey = 'test1234';
       var validTill = DateTime.now().subtract(const Duration(days: 1));
 
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       config.returnsCacheObject(fileUrl, fileName, validTill, key: fileKey);
       await config.returnsFile(fileName);
 
@@ -276,7 +276,7 @@ void main() {
       var extension = 'jpg';
 
       var store = MockStore();
-      var cacheManager = TestCacheManager(createTestConfig(), store: store);
+      var cacheManager = TestCacheManager(createTestCacheConfig(), store: store);
 
       var file = await cacheManager.putFile(fileUrl, fileBytes,
           fileExtension: extension);
@@ -292,7 +292,7 @@ void main() {
       var extension = 'jpg';
 
       var store = MockStore();
-      var cacheManager = TestCacheManager(createTestConfig(), store: store);
+      var cacheManager = TestCacheManager(createTestCacheConfig(), store: store);
 
       var file = await cacheManager.putFile(fileUrl, fileBytes,
           key: fileKey, fileExtension: extension);
@@ -315,7 +315,7 @@ void main() {
       await existingFile.writeAsBytes(fileBytes);
 
       var store = MockStore();
-      var cacheManager = TestCacheManager(createTestConfig(), store: store);
+      var cacheManager = TestCacheManager(createTestCacheConfig(), store: store);
 
       var file = await cacheManager.putFileStream(fileUrl, existingFile.openRead(),
           fileExtension: extension);
@@ -336,7 +336,7 @@ void main() {
       await existingFile.writeAsBytes(fileBytes);
 
       var store = MockStore();
-      var cacheManager = TestCacheManager(createTestConfig(), store: store);
+      var cacheManager = TestCacheManager(createTestCacheConfig(), store: store);
 
       var file = await cacheManager.putFileStream(fileUrl, existingFile.openRead(),
           key: fileKey, fileExtension: extension);
@@ -357,7 +357,7 @@ void main() {
       when(store.retrieveCacheData(fileUrl))
           .thenAnswer((_) => Future.value(CacheObject(fileUrl)));
 
-      var cacheManager = TestCacheManager(createTestConfig(), store: store);
+      var cacheManager = TestCacheManager(createTestCacheConfig(), store: store);
 
       await cacheManager.removeFile(fileUrl);
       verify(store.removeCachedFile(any)).called(1);
@@ -369,7 +369,7 @@ void main() {
       var store = MockStore();
       when(store.retrieveCacheData(fileUrl)).thenAnswer((_) => null);
 
-      var cacheManager = TestCacheManager(createTestConfig(), store: store);
+      var cacheManager = TestCacheManager(createTestCacheConfig(), store: store);
 
       await cacheManager.removeFile(fileUrl);
       verifyNever(store.removeCachedFile(any));
@@ -384,7 +384,7 @@ void main() {
     when(webHelper.downloadFile(fileUrl, key: anyNamed('key')))
         .thenAnswer((_) => Stream.value(fileInfo));
     var cacheManager = TestCacheManager(
-      createTestConfig(),
+      createTestCacheConfig(),
       webHelper: webHelper,
       store: store,
     );
@@ -399,7 +399,7 @@ void main() {
     when(store.getFileFromMemory(fileUrl))
         .thenAnswer((realInvocation) async => fileInfo);
     var webHelper = MockWebHelper();
-    var cacheManager = TestCacheManager(createTestConfig(),
+    var cacheManager = TestCacheManager(createTestCacheConfig(),
         store: store, webHelper: webHelper);
     var result = await cacheManager.getFileFromMemory(fileUrl);
     expect(result, fileInfo);
@@ -407,7 +407,7 @@ void main() {
 
   test('Empty cache empties cache in store', () async {
     var store = MockStore();
-    var cacheManager = TestCacheManager(createTestConfig(), store: store);
+    var cacheManager = TestCacheManager(createTestCacheConfig(), store: store);
     await cacheManager.emptyCache();
     verify(store.emptyCache()).called(1);
   });
@@ -416,7 +416,7 @@ void main() {
     test('Test progress from download', () async {
       var fileUrl = 'baseflow.com/test';
 
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       var fileService = config.fileService;
       var downloadStreamController = StreamController<List<int>>();
       when(fileService.get(fileUrl, headers: anyNamed('headers')))
@@ -452,7 +452,7 @@ void main() {
     });
 
     test("Don't get progress when not asked", () async {
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
 
       var fileUrl = 'baseflow.com/test';
 
@@ -499,7 +499,7 @@ class TestCacheManager extends CacheManager {
     CacheConfig config, {
     CacheStore store,
     WebHelper webHelper,
-  }) : super.custom(config ?? createTestConfig(),
+  }) : super.custom(config ?? createTestCacheConfig(),
             cacheStore: store, webHelper: webHelper);
 }
 

--- a/flutter_cache_manager/test/cache_manager_test.dart
+++ b/flutter_cache_manager/test/cache_manager_test.dart
@@ -496,7 +496,7 @@ void main() {
 
 class TestCacheManager extends CacheManager {
   TestCacheManager(
-    Config config, {
+    CacheConfig config, {
     CacheStore store,
     WebHelper webHelper,
   }) : super.custom(config ?? createTestConfig(),

--- a/flutter_cache_manager/test/cache_store_test.dart
+++ b/flutter_cache_manager/test/cache_store_test.dart
@@ -15,7 +15,7 @@ void main() {
     test('Store should return null when file not cached', () async {
       var repo = MockRepo();
       when(repo.get(any)).thenAnswer((_) => Future.value(null));
-      var store = CacheStore(createTestConfig());
+      var store = CacheStore(createTestCacheConfig());
 
       expect(await store.getFile('This is a test'), null);
     });
@@ -24,7 +24,7 @@ void main() {
       var fileName = 'testimage.png';
       var fileUrl = 'baseflow.com/test.png';
 
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       await config.returnsFile(fileName);
       config.returnsCacheObject(fileUrl, fileName, DateTime.now());
 
@@ -41,7 +41,7 @@ void main() {
 
       when(repo.get('baseflow.com/test.png')).thenAnswer((_) => Future.value(
           CacheObject('baseflow.com/test.png', relativePath: 'testimage.png')));
-      var store = CacheStore(createTestConfig());
+      var store = CacheStore(createTestCacheConfig());
 
       expect(await store.getFile('baseflow.com/test.png'), null);
     });
@@ -49,7 +49,7 @@ void main() {
     test('Store should return no CacheInfo when file not cached', () async {
       var repo = MockRepo();
       when(repo.get(any)).thenAnswer((_) => Future.value(null));
-      var store = CacheStore(createTestConfig());
+      var store = CacheStore(createTestCacheConfig());
 
       expect(await store.retrieveCacheData('This is a test'), null);
     });
@@ -58,7 +58,7 @@ void main() {
       var fileName = 'testimage.png';
       var fileUrl = 'baseflow.com/test.png';
 
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       await config.returnsFile(fileName);
       config.returnsCacheObject(fileUrl, fileName, DateTime.now());
 
@@ -72,7 +72,7 @@ void main() {
       var fileName = 'testimage.png';
       var fileUrl = 'baseflow.com/test.png';
       var validTill = DateTime.now();
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
 
       await config.returnsFile(fileName);
       config.returnsCacheObject(fileUrl, fileName, validTill);
@@ -90,7 +90,7 @@ void main() {
       var fileName = 'testimage.png';
       var fileUrl = 'baseflow.com/test.png';
       var validTill = DateTime.now();
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
 
       await config.returnsFile(fileName);
       config.returnsCacheObject(fileUrl, fileName, validTill);
@@ -105,7 +105,7 @@ void main() {
 
   group('Storing files in store', () {
     test('Store should store fileinfo in repo', () async {
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       var store = CacheStore(config);
 
       var cacheObject =
@@ -121,7 +121,7 @@ void main() {
       var fileName = 'testimage.png';
       var fileUrl = 'baseflow.com/test.png';
       var validTill = DateTime.now();
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
 
       await config.returnsFile(fileName);
       config.returnsCacheObject(fileUrl, fileName, validTill);
@@ -137,7 +137,7 @@ void main() {
     });
 
     test('Store should remove file over capacity', () async {
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       var store = CacheStore(config);
       store.cleanupRunMinInterval = const Duration(milliseconds: 1);
 
@@ -161,7 +161,7 @@ void main() {
     });
 
     test('Store should remove file over that are too old', () async {
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       var store = CacheStore(config);
       store.cleanupRunMinInterval = const Duration(milliseconds: 1);
       await config.returnsFile('testimage.png');
@@ -186,7 +186,7 @@ void main() {
     });
 
     test('Store should remove file old and over capacity', () async {
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       var store = CacheStore(config);
       store.cleanupRunMinInterval = const Duration(milliseconds: 1);
       await config.returnsFile('testimage.png');
@@ -213,7 +213,7 @@ void main() {
     });
 
     test('Store should recheck cache info when file is removed', () async {
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       var store = CacheStore(config);
       store.cleanupRunMinInterval = const Duration(milliseconds: 1);
       var file = await config.returnsFile('testimage.png');
@@ -234,7 +234,7 @@ void main() {
 
     test('Store should not remove files that are not old or over capacity',
         () async {
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       var store = CacheStore(config);
       store.cleanupRunMinInterval = const Duration(milliseconds: 1);
       await config.returnsFile('testimage.png');
@@ -257,7 +257,7 @@ void main() {
     });
 
     test('Store should remove all files when emptying cache', () async {
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       var store = CacheStore(config);
       store.cleanupRunMinInterval = const Duration(milliseconds: 1);
       await config.returnsFile('testimage.png');

--- a/flutter_cache_manager/test/helpers/config_extensions.dart
+++ b/flutter_cache_manager/test/helpers/config_extensions.dart
@@ -3,7 +3,7 @@ import 'package:flutter_cache_manager/src/config/config.dart';
 import 'package:flutter_cache_manager/src/storage/cache_object.dart';
 import 'package:mockito/mockito.dart';
 
-extension ConfigExtensions on Config {
+extension ConfigExtensions on CacheConfig {
   Future<File> returnsFile(String fileName) async {
     var file = await fileSystem.createFile(fileName);
     await (file.openWrite()..add([1, 3])).close();

--- a/flutter_cache_manager/test/helpers/test_configuration.dart
+++ b/flutter_cache_manager/test/helpers/test_configuration.dart
@@ -6,8 +6,8 @@ import 'package:flutter_cache_manager/src/storage/file_system/file_system.dart';
 import 'mock_cache_info_repository.dart';
 import 'mock_file_service.dart';
 
-Config createTestConfig() {
-  return Config(
+CacheConfig createTestConfig() {
+  return CacheConfig(
     'test',
     fileSystem: TestFileSystem(),
     repo: MockCacheInfoRepository(),

--- a/flutter_cache_manager/test/helpers/test_configuration.dart
+++ b/flutter_cache_manager/test/helpers/test_configuration.dart
@@ -6,7 +6,7 @@ import 'package:flutter_cache_manager/src/storage/file_system/file_system.dart';
 import 'mock_cache_info_repository.dart';
 import 'mock_file_service.dart';
 
-CacheConfig createTestConfig() {
+CacheConfig createTestCacheConfig() {
   return CacheConfig(
     'test',
     fileSystem: TestFileSystem(),

--- a/flutter_cache_manager/test/web_helper_test.dart
+++ b/flutter_cache_manager/test/web_helper_test.dart
@@ -19,7 +19,7 @@ void main() {
     test('200 is OK', () async {
       const imageUrl = 'baseflow.com/testimage';
 
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       var store = CacheStore(config);
 
       final fileService = MockFileService();
@@ -43,7 +43,7 @@ void main() {
 
     test('200 needs content', () async {
       const imageUrl = 'baseflow.com/testimage';
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       var store = CacheStore(config);
 
       final fileService = MockFileService();
@@ -61,7 +61,7 @@ void main() {
     test('404 throws', () async {
       const imageUrl = 'baseflow.com/testimage';
 
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       var store = CacheStore(config);
 
       final fileService = MockFileService();
@@ -82,7 +82,7 @@ void main() {
     test('304 ignores content', () async {
       const imageUrl = 'baseflow.com/testimage';
 
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       var store = CacheStore(config);
 
       final fileService = MockFileService();
@@ -104,7 +104,7 @@ void main() {
     test('Calling webhelper twice excecutes once', () async {
       const imageUrl = 'baseflow.com/testimage';
 
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       var store = _createStore(config);
 
       final fileService = MockFileService();
@@ -132,7 +132,7 @@ void main() {
         () async {
       const imageUrl = 'baseflow.com/testimage';
 
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       var store = _createStore(config);
 
       final fileService = MockFileService();
@@ -162,7 +162,7 @@ void main() {
       const url3 = 'baseflow.com/testimage3';
 
 
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       var store = _createStore(config);
       final fileService = MockFileService();
 
@@ -202,7 +202,7 @@ void main() {
       const fileName = 'testv1.jpg';
       final validTill = DateTime.now();
 
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       var store = _createStore(config);
       config.returnsCacheObject(imageUrl, fileName, validTill);
 
@@ -230,7 +230,7 @@ void main() {
       const imageUrl = 'baseflow.com/testimage';
       var imageName = 'image.png';
 
-      var config = createTestConfig();
+      var config = createTestCacheConfig();
       var store = CacheStore(config);
       var file = await config.returnsFile(imageName);
       config.returnsCacheObject(imageUrl, imageName, DateTime.now());

--- a/flutter_cache_manager/test/web_helper_test.dart
+++ b/flutter_cache_manager/test/web_helper_test.dart
@@ -247,7 +247,7 @@ void main() {
   });
 }
 
-MockStore _createStore(Config config) {
+MockStore _createStore(CacheConfig config) {
   final store = MockStore();
   when(store.putFile(argThat(anything)))
       .thenAnswer((_) => Future.value(VoidCallback));


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Enhancement / Compatibility


### :arrow_heading_down: What is the current behavior?
The CacheManager is configured by an object called `Config`


### :new: What is the new behavior (if this is a feature change)?
After this PR `Config` will be renamed to `CacheConfig` to have a less generic name for such a specific purpose


### :boom: Does this PR introduce a breaking change?
Yes


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #237


### :thinking: Checklist before submitting

- [ ] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
