### PR TITLE
Raise minimum sqflite version

### DIFF
--- a/flutter_cache_manager/example/pubspec.yaml
+++ b/flutter_cache_manager/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.6.0 <3.0.0"
+  sdk: ">=2.10.2 <3.0.0"
 
 dependencies:
   flutter:

--- a/flutter_cache_manager/pubspec.yaml
+++ b/flutter_cache_manager/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   uuid:  ^2.0.2
   http: ^0.12.0+2
   path: ^1.6.4
-  sqflite: ^1.1.7+2
+  sqflite: ^1.3.2+1
   pedantic: ^1.8.0+1
   clock: ^1.0.1
   file: ">=5.1.0 <7.0.0"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This PR fixes a build failure.

### :arrow_heading_down: What is the current behavior?
Build fails with error `The method 'isDuplicateColumnError' isn't defined for the class 'DatabaseException'.` when sqflite version lower than 1.3.1 is used.

### :new: What is the new behavior (if this is a feature change)?
A compatible version of sqflite will be used. If an incompatible version of sqflite is forced elsewhere(for example in app's pubspec.yaml), `flutter pub get` will fail with an easy to understand message saying that wrong version of sqflite is being used.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #242

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
