### PR TITLE
https://github.com/Baseflow/flutter_cache_manager/issues/135

### DIFF
--- a/flutter_cache_manager/lib/src/storage/file_system/file_system_io.dart
+++ b/flutter_cache_manager/lib/src/storage/file_system/file_system_io.dart
@@ -7,8 +7,9 @@ import 'file_system.dart';
 
 class IOFileSystem implements FileSystem {
   final Future<Directory> _fileDir;
+  final String _cacheKey;
 
-  IOFileSystem(String key) : _fileDir = createDirectory(key);
+  IOFileSystem(this._cacheKey) : _fileDir = createDirectory(_cacheKey);
 
   static Future<Directory> createDirectory(String key) async {
     var baseDir = await getTemporaryDirectory();
@@ -23,6 +24,10 @@ class IOFileSystem implements FileSystem {
   @override
   Future<File> createFile(String name) async {
     assert(name != null);
-    return (await _fileDir).childFile(name);
+    var directory = (await _fileDir);
+    if (!(await directory.exists())) {
+      await createDirectory(_cacheKey);
+    }
+    return directory.childFile(name);
   }
 }


### PR DESCRIPTION
https://github.com/Baseflow/flutter_cache_manager/issues/135
https://github.com/Baseflow/flutter_cached_network_image/issues/399

**Issue:**
Cannot open file, path = '/var/mobile/Containers/Data/Application/
B861D1-3A04-498D-AC67-23E00574DD1C/Library/Caches/
libCachedImageData/fdbf1150-a040-11ea-d6f9-4168d77.bin' 
(OS Error: No such file or directory, errno = 2)

**Repo:**

Go to the Application Settings of the Android system to clear the application cache. Do not clear all data
At this point, go back to your Flutter app and look at the image loaded. The image cannot be displayed. you will get 

"Cannot open file, path = '/var/mobile/Containers/Data/Application/
B861D1-3A04-498D-AC67-23E00574DD1C/Library/Caches/
libCachedImageData/fdbf1150-a040-11ea-d6f9-4168d77.bin' 
(OS Error: No such file or directory, errno = 2)"

**Problem:**

Because **libCachedImageData** sub-folder will be removed while clear cache from setting. So file.openWrite() will not create the file and will throw the above exception.

File: web_helper.dart
Function: _saveFileAndPostUpdates
Line Number: 189
Code:  final sink = file.openWrite();

### :sparkles: What kind of change does this PR introduce? Bug fix


### :arrow_heading_down: What is the current behavior? - Develop


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing - Not required


### :memo: Links to relevant issues/docs
https://github.com/Baseflow/flutter_cache_manager/issues/135
https://github.com/Baseflow/flutter_cached_network_image/issues/399


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
