### PR TITLE
reportError when reading json file fails

### DIFF
--- a/flutter_cache_manager/lib/src/storage/cache_info_repositories/json_cache_info_repository.dart
+++ b/flutter_cache_manager/lib/src/storage/cache_info_repositories/json_cache_info_repository.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
 
+import 'package:flutter/widgets.dart';
 import 'package:flutter_cache_manager/src/storage/cache_object.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
@@ -141,14 +142,25 @@ class JsonCacheInfoRepository extends CacheInfoRepository
     _cacheObjects = {};
     _jsonCache = {};
     if (await _file.exists()) {
-      var jsonString = await _file.readAsString();
-      var json = jsonDecode(jsonString) as List<dynamic>;
-      for (var element in json) {
-        if (element is! Map<String, dynamic>) continue;
-        var map = element as Map<String, dynamic>;
-        var cacheObject = CacheObject.fromMap(map);
-        _jsonCache[cacheObject.id] = map;
-        _cacheObjects[cacheObject.key] = cacheObject;
+      try {
+        var jsonString = await _file.readAsString();
+        var json = jsonDecode(jsonString) as List<dynamic>;
+        for (var element in json) {
+          if (element is! Map<String, dynamic>) continue;
+          var map = element as Map<String, dynamic>;
+          var cacheObject = CacheObject.fromMap(map);
+          _jsonCache[cacheObject.id] = map;
+          _cacheObjects[cacheObject.key] = cacheObject;
+        }
+      }catch(e, stacktrace){
+        FlutterError.reportError(FlutterErrorDetails(
+          exception: e,
+          stack: stacktrace,
+          library: 'flutter cache manager',
+          context: ErrorDescription('Thrown when reading the file containing '
+              'cache info. The cached files cannot be used by the cache manager'
+              'anymore.'),
+        ));
       }
     }
   }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When the json file is corrupt, the cache is completely broken.

### :new: What is the new behavior (if this is a feature change)?
When reading the file fails it just continues with an empty file. It does report the error to the error handlers.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Best to test by corrupting the file.

### :memo: Links to relevant issues/docs
Fixes #262

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
