### PR TITLE
Add null safety to Firebase cache manager

### DIFF
--- a/flutter_cache_manager_firebase/CHANGELOG.md
+++ b/flutter_cache_manager_firebase/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.0.0] - 2021-05-28
+* Update to null safety
+
 ## [1.1.0] - 2021-01-14
 * Update Firebase dependency
 

--- a/flutter_cache_manager_firebase/lib/src/firebase_cache_manager.dart
+++ b/flutter_cache_manager_firebase/lib/src/firebase_cache_manager.dart
@@ -7,11 +7,10 @@ import 'firebase_http_file_service.dart';
 class FirebaseCacheManager extends CacheManager {
   static const key = 'firebaseCache';
 
-  static FirebaseCacheManager? _instance;
+  static late final FirebaseCacheManager _instance = FirebaseCacheManager._();
 
   factory FirebaseCacheManager() {
-    _instance ??= FirebaseCacheManager._();
-    return _instance!;
+    return _instance;
   }
 
   FirebaseCacheManager._()

--- a/flutter_cache_manager_firebase/lib/src/firebase_cache_manager.dart
+++ b/flutter_cache_manager_firebase/lib/src/firebase_cache_manager.dart
@@ -7,11 +7,11 @@ import 'firebase_http_file_service.dart';
 class FirebaseCacheManager extends CacheManager {
   static const key = 'firebaseCache';
 
-  static FirebaseCacheManager _instance;
+  static FirebaseCacheManager? _instance;
 
   factory FirebaseCacheManager() {
     _instance ??= FirebaseCacheManager._();
-    return _instance;
+    return _instance!;
   }
 
   FirebaseCacheManager._()

--- a/flutter_cache_manager_firebase/lib/src/firebase_http_file_service.dart
+++ b/flutter_cache_manager_firebase/lib/src/firebase_http_file_service.dart
@@ -7,7 +7,7 @@ import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 class FirebaseHttpFileService extends HttpFileService {
   @override
   Future<FileServiceResponse> get(String url,
-      {Map<String, String>? headers = const {}}) async {
+      {Map<String, String>? headers}) async {
     var ref = FirebaseStorage.instance.ref().child(url);
     var _url = await ref.getDownloadURL();
 

--- a/flutter_cache_manager_firebase/lib/src/firebase_http_file_service.dart
+++ b/flutter_cache_manager_firebase/lib/src/firebase_http_file_service.dart
@@ -7,9 +7,9 @@ import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 class FirebaseHttpFileService extends HttpFileService {
   @override
   Future<FileServiceResponse> get(String url,
-      {Map<String, String> headers = const {}}) async {
+      {Map<String, String>? headers = const {}}) async {
     var ref = FirebaseStorage.instance.ref().child(url);
-    var _url = await ref.getDownloadURL() as String;
+    var _url = await ref.getDownloadURL();
 
     return super.get(_url);
   }

--- a/flutter_cache_manager_firebase/pubspec.yaml
+++ b/flutter_cache_manager_firebase/pubspec.yaml
@@ -4,15 +4,15 @@ version: 1.1.0
 homepage: https://github.com/Baseflow/flutter_cache_manager
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_cache_manager: ^2.0.0
-  firebase_storage: ">=3.0.0 <6.0.0"
-  path_provider: "^1.4.0"
-  path: "^1.6.4"
+  flutter_cache_manager: ^3.0.0-nullsafety.0
+  firebase_storage: ">=8.0.0 <9.0.0"
+  path_provider: ^2.0.0
+  path: ^1.8.0
 
 dev_dependencies:
   flutter_test:

--- a/flutter_cache_manager_firebase/pubspec.yaml
+++ b/flutter_cache_manager_firebase/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_cache_manager_firebase
 description: CacheManager implementation for firebase_storage. Uses the gs:// as key and translates to https://
-version: 2.0.0-nullsafety.0
+version: 2.0.0
 homepage: https://github.com/Baseflow/flutter_cache_manager
 
 environment:
@@ -9,8 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_cache_manager: ^3.0.0-nullsafety.0
-  firebase_storage: ">=8.0.0 <9.0.0"
+  flutter_cache_manager: ^3.0.0
+  firebase_storage: ^8.0.0
   path_provider: ^2.0.0
   path: ^1.8.0
 

--- a/flutter_cache_manager_firebase/pubspec.yaml
+++ b/flutter_cache_manager_firebase/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_cache_manager_firebase
 description: CacheManager implementation for firebase_storage. Uses the gs:// as key and translates to https://
-version: 1.1.0
+version: 2.0.0-nullsafety.0
 homepage: https://github.com/Baseflow/flutter_cache_manager
 
 environment:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This PR adds null safety to Firebase cache manager and updates dependencies to their null safe versions.

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
