### PR TITLE
Expose `File` from package `file`

### DIFF
--- a/flutter_cache_manager/lib/flutter_cache_manager.dart
+++ b/flutter_cache_manager/lib/flutter_cache_manager.dart
@@ -6,3 +6,4 @@ export 'src/result/result.dart';
 export 'src/storage/cache_info_repositories/cache_info_repositories.dart';
 export 'src/web/file_service.dart';
 export 'src/web/web_helper.dart' show HttpExceptionWithStatus;
+export 'package:file/file.dart' show File;


### PR DESCRIPTION
This prevents the need to unnecessarily have `file` as a direct dependency

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Update exports

### :arrow_heading_down: What is the current behavior?

`File` is not exported. This means, to type annotate variables, users have to add `file` as a direct dependencies and import it.

### :new: What is the new behavior (if this is a feature change)?

`File` is exported.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

N/A

### :memo: Links to relevant issues/docs

N/A

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
