### PR TITLE
Don't add `if-none-match` header manually

### DIFF
--- a/flutter_cache_manager/lib/src/web/web_helper.dart
+++ b/flutter_cache_manager/lib/src/web/web_helper.dart
@@ -105,6 +105,13 @@ class WebHelper {
     if (authHeaders != null) {
       headers.addAll(authHeaders);
     }
+    
+    final etag = cacheObject.eTag;
+
+    // Adding `if-none-match` header on web causes a CORS error.
+    if (etag != null && !kIsWeb) { 
+      headers[HttpHeaders.ifNoneMatchHeader] = etag;
+    }
 
     return fileFetcher.get(cacheObject.url, headers: headers);
   }

--- a/flutter_cache_manager/lib/src/web/web_helper.dart
+++ b/flutter_cache_manager/lib/src/web/web_helper.dart
@@ -105,7 +105,7 @@ class WebHelper {
     if (authHeaders != null) {
       headers.addAll(authHeaders);
     }
-    
+
     final etag = cacheObject.eTag;
 
     // Adding `if-none-match` header on web causes a CORS error.

--- a/flutter_cache_manager/lib/src/web/web_helper.dart
+++ b/flutter_cache_manager/lib/src/web/web_helper.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:clock/clock.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_cache_manager/src/result/file_response.dart';
 import 'package:flutter_cache_manager/src/storage/cache_object.dart';

--- a/flutter_cache_manager/lib/src/web/web_helper.dart
+++ b/flutter_cache_manager/lib/src/web/web_helper.dart
@@ -106,11 +106,6 @@ class WebHelper {
       headers.addAll(authHeaders);
     }
 
-    final etag = cacheObject.eTag;
-    if (etag != null) {
-      headers[HttpHeaders.ifNoneMatchHeader] = etag;
-    }
-
     return fileFetcher.get(cacheObject.url, headers: headers);
   }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bugfix / Caching strategy update

### :arrow_heading_down: What is the current behavior?

If `eTag` is returned by the server, `if-none-match` header is added on subsequent requests which -

1. Triggers preflight requests
2. Throws CORS error as the server doesn't support manually added `if-none-match` headers

### :new: What is the new behavior (if this is a feature change)?

`if-none-match` is not added manually. The browser handles this for us.


### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

If tests try matching request headers, remove `if-none-match` from the list.

### :memo: Links to relevant issues/docs

[web.dev article](https://web.dev/http-cache/) on how the browser handles `eTag`s and adding required headers for the same.

Closes #316

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
