### PR TITLE
loading from one url multiple times simultaneously throws

### DIFF
--- a/flutter_cache_manager/lib/src/cache_managers/image_cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_managers/image_cache_manager.dart
@@ -52,7 +52,7 @@ mixin ImageCacheManager on BaseCacheManager {
         withProgress,
         maxWidth: maxWidth,
         maxHeight: maxHeight,
-      );
+      ).asBroadcastStream();
       _runningResizes[resizedKey] = runningResize;
     }
     yield* runningResize;


### PR DESCRIPTION
If you try to load an image in two different places simultaneously, it will try to listen to an already listened to stream and throw a Bad State Error. Making the stream broadcast fixes this.