### PR TITLE
Fix breaking change by hiding File again

### DIFF
--- a/flutter_cache_manager/CHANGELOG.md
+++ b/flutter_cache_manager/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [3.1.1] - 2021-06-02
+* Revert exporting `File` from `package:file` due to conflicts with `dart:io` ([#321](https://github.com/Baseflow/flutter_cache_manager/pull/321))
+
 ## [3.1.0] - 2021-05-28
 * Export File from package file ([#302](https://github.com/Baseflow/flutter_cache_manager/pull/302))
 * Bugfix for eTag on Flutter Web ([#304](https://github.com/Baseflow/flutter_cache_manager/pull/315))

--- a/flutter_cache_manager/lib/flutter_cache_manager.dart
+++ b/flutter_cache_manager/lib/flutter_cache_manager.dart
@@ -1,5 +1,3 @@
-export 'package:file/file.dart' show File;
-
 export 'src/cache_manager.dart';
 export 'src/cache_managers/cache_managers.dart';
 export 'src/compat/file_fetcher.dart';

--- a/flutter_cache_manager/pubspec.yaml
+++ b/flutter_cache_manager/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_cache_manager
 description: Generic cache manager for flutter. Saves web files on the storages of the device and saves the cache info using sqflite.
-version: 3.1.0
+version: 3.1.1
 homepage: https://github.com/Baseflow/flutter_cache_manager
 
 environment:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

This fixes the breaking change I explained in https://github.com/Baseflow/flutter_cache_manager/pull/302#issuecomment-853120621.

### :arrow_heading_down: What is the current behavior?

When you run `pub upgrade` with `flutter_cache_manager: ^3.0.0` and used `3.0.0` before, your code breaks because you might have imported `dart:io` (or `universal_io`) and `flutter_cache_manager` in the same file.

### :new: What is the new behavior (if this is a feature change)?

Removed the `export` of `package:file`. Instead, users can `import` it when needed.

## What should be done instead?

@sidrao2006 said that you have to add a direct `package:file` depedendency if you want to annotate types without his PR (this **reverts** #302), however, that is **not true**.

You can import `package:file/file.dart`, even when it is a transitive dependency.

### Migration

So the migration is simply adding:

```dart
import 'package:file/file.dart' show File;
```

Whenever you want to use that `File` class.

### :boom: Does this PR introduce a breaking change?

Technically yes, but it fixes the previous breaking change.

### :thinking: Checklist before submitting

- [x] All projects build
- [x ] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
