### PR TITLE
Await file removal to prevent unexpected results

### DIFF
--- a/flutter_cache_manager/lib/src/cache_store.dart
+++ b/flutter_cache_manager/lib/src/cache_store.dart
@@ -165,7 +165,7 @@ class CacheStore {
   Future<void> removeCachedFile(CacheObject cacheObject) async {
     final provider = await _cacheInfoRepository;
     final toRemove = <int>[];
-    unawaited(_removeCachedFile(cacheObject, toRemove));
+    await _removeCachedFile(cacheObject, toRemove);
     await provider.deleteAll(toRemove);
   }
 
@@ -182,7 +182,7 @@ class CacheStore {
     }
     final file = await fileSystem.createFile(cacheObject.relativePath);
     if (await file.exists()) {
-      unawaited(file.delete());
+      await file.delete();
     }
   }
 


### PR DESCRIPTION
### :arrow_heading_down: What is the current behavior?

File removal is not awaited. Due to this, calling `CacheManager.removeFile` appears to have flaky performance. 

### :new: What is the new behavior (if this is a feature change)?

File removal is awaited. The `Future` returned by `removeFile` completes when file is removed. 

### :boom: Does this PR introduce a breaking change?

No, but it does slow down any callers of this method which `await` it's result

### :memo: Links to relevant issues/docs

Fixes #317

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
