### PR TITLE
Update cache_manager.dart

### DIFF
--- a/flutter_cache_manager/lib/src/cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_manager.dart
@@ -71,7 +71,7 @@ class CacheManager implements BaseCacheManager {
   /// downloaded in the background. When a cached file is not available the
   /// newly downloaded file is returned.
   @override
-  Future<File> getSingleFile(
+  Future<File?> getSingleFile(
     String url, {
     String? key,
     Map<String, String>? headers,


### PR DESCRIPTION
make getSingleFile nullable

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

allows `getSingleFile` to return a nullable object

### :arrow_heading_down: What is the current behavior?
the function cannot return a nullable.

### :new: What is the new behavior (if this is a feature change)?
If a file from a url is not available for whatever reason (maybe the file was deleted from the server), we should be able to use the `onError` function to return null. currently we can only return null if we `await` the file future, which can be slow.

### :boom: Does this PR introduce a breaking change?
no

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
