### PR TITLE
Fix race condition of expired cache files

### DIFF
--- a/flutter_cache_manager/lib/src/cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_manager.dart
@@ -78,10 +78,7 @@ class CacheManager implements BaseCacheManager {
   }) async {
     key ??= url;
     final cacheFile = await getFileFromCache(key);
-    if (cacheFile != null) {
-      if (cacheFile.validTill.isBefore(DateTime.now())) {
-        unawaited(downloadFile(url, key: key, authHeaders: headers));
-      }
+    if (cacheFile != null && cacheFile.validTill.isAfter(DateTime.now())) {
       return cacheFile.file;
     }
     return (await downloadFile(url, key: key, authHeaders: headers)).file;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

A bug of downloading-accessing race condition was fixed.

Here `CacheManager.getSingleFile()` was refactored to clarify two
situations.

- Cache exist and not expired: return the cache.
- Otherwise: just call `downloadFile()` and wait. Class `WebHelper` will
  do the rest for us smartly (Using `If-None-Match` HTTP request header).

### :arrow_heading_down: What is the current behavior?

While cache expired, the original implementation returns older cache
information without waiting for possible new-downloaded file or
modification check. In situations where ETag has changed, updated file
will be downloaded using a new file name and old cache file be deleted
(according to `WebHelper._manageResponse()` and
`WebHelper._setDataFromHeaders()`).

If old cache file is returned immediately as in the original
implementation, in cases where the old cache file is still consuming,
it'll be very likely deleted by web helper routine. Thus
downloading-accessing race condition arise.

### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

It's a little tricky to reproduce this race condition bug. Using a very short valid time image, try to repeatedly get the image and update the picture widget. Substitute the image with another one on server (Same URL but changed ETag then), the repeating routine in the App will fail with exception(can't read the file). The reason is that the newly downloaded file has different file name than the old one (which is deleted by cache manager).

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
