### PR TITLE
Disable resizing of gifs

### DIFF
--- a/flutter_cache_manager/CHANGELOG.md
+++ b/flutter_cache_manager/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [3.1.3] - 2021-11-05
+* Disabled resizing of cached gifs as this was broken.
+
 ## [3.1.2] - 2021-06-17
 * removeFile function now completes after the file is removed from disk and not earlier ([#323](https://github.
   com/Baseflow/flutter_cache_manager/pull/323))

--- a/flutter_cache_manager/lib/src/cache_managers/image_cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_managers/image_cache_manager.dart
@@ -6,7 +6,7 @@ import 'package:file/file.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 
-const supportedFileNames = ['jpg', 'jpeg', 'png', 'tga', 'gif', 'cur', 'ico'];
+const supportedFileNames = ['jpg', 'jpeg', 'png', 'tga', 'cur', 'ico'];
 mixin ImageCacheManager on BaseCacheManager {
   /// Returns a resized image file to fit within maxHeight and maxWidth. It
   /// tries to keep the aspect ratio. It stores the resized image by adding

--- a/flutter_cache_manager/pubspec.yaml
+++ b/flutter_cache_manager/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_cache_manager
 description: Generic cache manager for flutter. Saves web files on the storages of the device and saves the cache info using sqflite.
-version: 3.1.2
+version: 3.1.3
 homepage: https://github.com/Baseflow/flutter_cache_manager
 
 environment:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Currently the library tries to resize gifs, but this goes wrong if done while being shown already.

### :new: What is the new behavior (if this is a feature change)?
Gifs are not marked anymore as supported files for resizing.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Could be tested with any gif with a set height, see https://github.com/Baseflow/flutter_cached_network_image/issues/655#issuecomment-961322852

### :memo: Links to relevant issues/docs
* https://github.com/Baseflow/flutter_cached_network_image/issues/655

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
