### PR TITLE
expose memoryCacheContainsKey method from cache_store

### DIFF
--- a/flutter_cache_manager/lib/src/cache_store.dart
+++ b/flutter_cache_manager/lib/src/cache_store.dart
@@ -188,6 +188,10 @@ class CacheStore {
     }
   }
 
+  bool memoryCacheContainsKey(String key) {
+    return _memCache.containsKey(key);
+  }
+
   Future<void> dispose() async {
     final provider = await _cacheInfoRepository;
     await provider.close();

--- a/flutter_cache_manager/test/cache_store_test.dart
+++ b/flutter_cache_manager/test/cache_store_test.dart
@@ -144,7 +144,9 @@ void main() {
       verify(config.repo.updateOrInsert(cacheObject)).called(1);
     });
 
-    test('Store should store fileinfo in repo and id should be available afterwards', () async {
+    test(
+        'Store should store fileinfo in repo and id should be available afterwards',
+        () async {
       var config = createTestConfig();
 
       var cacheObject = CacheObject(
@@ -189,7 +191,8 @@ void main() {
       );
       await store.removeCachedFile(cacheObject);
 
-      verify(config.mockRepo.deleteAll(argThat(contains(cacheObject.id)))).called(1);
+      verify(config.mockRepo.deleteAll(argThat(contains(cacheObject.id))))
+          .called(1);
     });
 
     test('Store should remove file over capacity', () async {
@@ -205,16 +208,20 @@ void main() {
       );
       await config.returnsFile('testimage.png');
 
-      when(config.mockRepo.getObjectsOverCapacity(any)).thenAnswer((_) => Future.value([cacheObject]));
-      when(config.mockRepo.getOldObjects(any)).thenAnswer((_) => Future.value([]));
-      when(config.mockRepo.get('baseflow.com/test.png')).thenAnswer((_) => Future.value(cacheObject));
+      when(config.mockRepo.getObjectsOverCapacity(any))
+          .thenAnswer((_) => Future.value([cacheObject]));
+      when(config.mockRepo.getOldObjects(any))
+          .thenAnswer((_) => Future.value([]));
+      when(config.mockRepo.get('baseflow.com/test.png'))
+          .thenAnswer((_) => Future.value(cacheObject));
 
       expect(await store.getFile('baseflow.com/test.png'), isNotNull);
 
       await untilCalled(config.mockRepo.deleteAll(any));
 
       verify(config.mockRepo.getObjectsOverCapacity(any)).called(1);
-      verify(config.mockRepo.deleteAll(argThat(contains(cacheObject.id)))).called(1);
+      verify(config.mockRepo.deleteAll(argThat(contains(cacheObject.id))))
+          .called(1);
     });
 
     test('Store should remove file over that are too old', () async {
@@ -230,16 +237,20 @@ void main() {
         validTill: clock.now().add(const Duration(days: 7)),
       );
 
-      when(config.mockRepo.getObjectsOverCapacity(any)).thenAnswer((_) => Future.value([]));
-      when(config.mockRepo.getOldObjects(any)).thenAnswer((_) => Future.value([cacheObject]));
-      when(config.mockRepo.get('baseflow.com/test.png')).thenAnswer((_) => Future.value(cacheObject));
+      when(config.mockRepo.getObjectsOverCapacity(any))
+          .thenAnswer((_) => Future.value([]));
+      when(config.mockRepo.getOldObjects(any))
+          .thenAnswer((_) => Future.value([cacheObject]));
+      when(config.mockRepo.get('baseflow.com/test.png'))
+          .thenAnswer((_) => Future.value(cacheObject));
 
       expect(await store.getFile('baseflow.com/test.png'), isNotNull);
 
       await untilCalled(config.mockRepo.deleteAll(any));
 
       verify(config.mockRepo.getOldObjects(any)).called(1);
-      verify(config.mockRepo.deleteAll(argThat(contains(cacheObject.id)))).called(1);
+      verify(config.mockRepo.deleteAll(argThat(contains(cacheObject.id))))
+          .called(1);
     });
 
     test('Store should remove file old and over capacity', () async {
@@ -255,9 +266,12 @@ void main() {
         validTill: clock.now().add(const Duration(days: 7)),
       );
 
-      when(config.mockRepo.getObjectsOverCapacity(any)).thenAnswer((_) => Future.value([cacheObject]));
-      when(config.mockRepo.getOldObjects(any)).thenAnswer((_) => Future.value([cacheObject]));
-      when(config.mockRepo.get('baseflow.com/test.png')).thenAnswer((_) => Future.value(cacheObject));
+      when(config.mockRepo.getObjectsOverCapacity(any))
+          .thenAnswer((_) => Future.value([cacheObject]));
+      when(config.mockRepo.getOldObjects(any))
+          .thenAnswer((_) => Future.value([cacheObject]));
+      when(config.mockRepo.get('baseflow.com/test.png'))
+          .thenAnswer((_) => Future.value(cacheObject));
 
       expect(await store.getFile('baseflow.com/test.png'), isNotNull);
 
@@ -266,7 +280,8 @@ void main() {
 
       verify(config.mockRepo.getObjectsOverCapacity(any)).called(1);
       verify(config.mockRepo.getOldObjects(any)).called(1);
-      verify(config.mockRepo.deleteAll(argThat(contains(cacheObject.id)))).called(1);
+      verify(config.mockRepo.deleteAll(argThat(contains(cacheObject.id))))
+          .called(1);
     });
 
     test('Store should recheck cache info when file is removed', () async {
@@ -282,16 +297,20 @@ void main() {
         validTill: clock.now().add(const Duration(days: 7)),
       );
 
-      when(config.mockRepo.getObjectsOverCapacity(any)).thenAnswer((_) => Future.value([]));
-      when(config.mockRepo.getOldObjects(any)).thenAnswer((_) => Future.value([]));
-      when(config.mockRepo.get('baseflow.com/test.png')).thenAnswer((_) => Future.value(cacheObject));
+      when(config.mockRepo.getObjectsOverCapacity(any))
+          .thenAnswer((_) => Future.value([]));
+      when(config.mockRepo.getOldObjects(any))
+          .thenAnswer((_) => Future.value([]));
+      when(config.mockRepo.get('baseflow.com/test.png'))
+          .thenAnswer((_) => Future.value(cacheObject));
 
       expect(await store.getFile('baseflow.com/test.png'), isNotNull);
       await file.delete();
       expect(await store.getFile('baseflow.com/test.png'), isNull);
     });
 
-    test('Store should not remove files that are not old or over capacity', () async {
+    test('Store should not remove files that are not old or over capacity',
+        () async {
       var config = createTestConfig();
       var store = CacheStore(config);
       store.cleanupRunMinInterval = const Duration(milliseconds: 1);
@@ -304,9 +323,12 @@ void main() {
         validTill: clock.now().add(const Duration(days: 7)),
       );
 
-      when(config.mockRepo.getObjectsOverCapacity(any)).thenAnswer((_) => Future.value([]));
-      when(config.mockRepo.getOldObjects(any)).thenAnswer((_) => Future.value([]));
-      when(config.mockRepo.get('baseflow.com/test.png')).thenAnswer((_) => Future.value(cacheObject));
+      when(config.mockRepo.getObjectsOverCapacity(any))
+          .thenAnswer((_) => Future.value([]));
+      when(config.mockRepo.getOldObjects(any))
+          .thenAnswer((_) => Future.value([]));
+      when(config.mockRepo.get('baseflow.com/test.png'))
+          .thenAnswer((_) => Future.value(cacheObject));
 
       expect(await store.getFile('baseflow.com/test.png'), isNotNull);
 
@@ -341,11 +363,13 @@ void main() {
         validTill: clock.now().add(const Duration(days: 7)),
       );
 
-      when(config.mockRepo.getAllObjects()).thenAnswer((_) => Future.value([co1, co2, co3]));
+      when(config.mockRepo.getAllObjects())
+          .thenAnswer((_) => Future.value([co1, co2, co3]));
 
       await store.emptyCache();
 
-      verify(config.mockRepo.deleteAll(argThat(containsAll([co1.id, co2.id, co3.id])))).called(1);
+      verify(config.mockRepo
+          .deleteAll(argThat(containsAll([co1.id, co2.id, co3.id])))).called(1);
     });
   });
 }

--- a/flutter_cache_manager/test/cache_store_test.dart
+++ b/flutter_cache_manager/test/cache_store_test.dart
@@ -110,6 +110,23 @@ void main() {
       await store.getFile(fileUrl);
       expect(await store.getFileFromMemory(fileUrl), isNotNull);
     });
+
+    test(
+        'Store.memoryCacheContainsKey should return true if the key is present in the memory cache',
+        () async {
+      var config = createTestConfig();
+      var store = CacheStore(config);
+
+      var cacheObject = CacheObject(
+        'baseflow.com/test.png',
+        relativePath: 'testimage.png',
+        validTill: clock.now().add(const Duration(days: 7)),
+      );
+      await store.putFile(cacheObject);
+
+      expect(store.memoryCacheContainsKey('baseflow.com/test.png'), true);
+      expect(store.memoryCacheContainsKey('unseen-file'), false);
+    });
   });
 
   group('Storing files in store', () {
@@ -127,9 +144,7 @@ void main() {
       verify(config.repo.updateOrInsert(cacheObject)).called(1);
     });
 
-    test(
-        'Store should store fileinfo in repo and id should be available afterwards',
-        () async {
+    test('Store should store fileinfo in repo and id should be available afterwards', () async {
       var config = createTestConfig();
 
       var cacheObject = CacheObject(
@@ -174,8 +189,7 @@ void main() {
       );
       await store.removeCachedFile(cacheObject);
 
-      verify(config.mockRepo.deleteAll(argThat(contains(cacheObject.id))))
-          .called(1);
+      verify(config.mockRepo.deleteAll(argThat(contains(cacheObject.id)))).called(1);
     });
 
     test('Store should remove file over capacity', () async {
@@ -191,20 +205,16 @@ void main() {
       );
       await config.returnsFile('testimage.png');
 
-      when(config.mockRepo.getObjectsOverCapacity(any))
-          .thenAnswer((_) => Future.value([cacheObject]));
-      when(config.mockRepo.getOldObjects(any))
-          .thenAnswer((_) => Future.value([]));
-      when(config.mockRepo.get('baseflow.com/test.png'))
-          .thenAnswer((_) => Future.value(cacheObject));
+      when(config.mockRepo.getObjectsOverCapacity(any)).thenAnswer((_) => Future.value([cacheObject]));
+      when(config.mockRepo.getOldObjects(any)).thenAnswer((_) => Future.value([]));
+      when(config.mockRepo.get('baseflow.com/test.png')).thenAnswer((_) => Future.value(cacheObject));
 
       expect(await store.getFile('baseflow.com/test.png'), isNotNull);
 
       await untilCalled(config.mockRepo.deleteAll(any));
 
       verify(config.mockRepo.getObjectsOverCapacity(any)).called(1);
-      verify(config.mockRepo.deleteAll(argThat(contains(cacheObject.id))))
-          .called(1);
+      verify(config.mockRepo.deleteAll(argThat(contains(cacheObject.id)))).called(1);
     });
 
     test('Store should remove file over that are too old', () async {
@@ -220,20 +230,16 @@ void main() {
         validTill: clock.now().add(const Duration(days: 7)),
       );
 
-      when(config.mockRepo.getObjectsOverCapacity(any))
-          .thenAnswer((_) => Future.value([]));
-      when(config.mockRepo.getOldObjects(any))
-          .thenAnswer((_) => Future.value([cacheObject]));
-      when(config.mockRepo.get('baseflow.com/test.png'))
-          .thenAnswer((_) => Future.value(cacheObject));
+      when(config.mockRepo.getObjectsOverCapacity(any)).thenAnswer((_) => Future.value([]));
+      when(config.mockRepo.getOldObjects(any)).thenAnswer((_) => Future.value([cacheObject]));
+      when(config.mockRepo.get('baseflow.com/test.png')).thenAnswer((_) => Future.value(cacheObject));
 
       expect(await store.getFile('baseflow.com/test.png'), isNotNull);
 
       await untilCalled(config.mockRepo.deleteAll(any));
 
       verify(config.mockRepo.getOldObjects(any)).called(1);
-      verify(config.mockRepo.deleteAll(argThat(contains(cacheObject.id))))
-          .called(1);
+      verify(config.mockRepo.deleteAll(argThat(contains(cacheObject.id)))).called(1);
     });
 
     test('Store should remove file old and over capacity', () async {
@@ -249,12 +255,9 @@ void main() {
         validTill: clock.now().add(const Duration(days: 7)),
       );
 
-      when(config.mockRepo.getObjectsOverCapacity(any))
-          .thenAnswer((_) => Future.value([cacheObject]));
-      when(config.mockRepo.getOldObjects(any))
-          .thenAnswer((_) => Future.value([cacheObject]));
-      when(config.mockRepo.get('baseflow.com/test.png'))
-          .thenAnswer((_) => Future.value(cacheObject));
+      when(config.mockRepo.getObjectsOverCapacity(any)).thenAnswer((_) => Future.value([cacheObject]));
+      when(config.mockRepo.getOldObjects(any)).thenAnswer((_) => Future.value([cacheObject]));
+      when(config.mockRepo.get('baseflow.com/test.png')).thenAnswer((_) => Future.value(cacheObject));
 
       expect(await store.getFile('baseflow.com/test.png'), isNotNull);
 
@@ -263,8 +266,7 @@ void main() {
 
       verify(config.mockRepo.getObjectsOverCapacity(any)).called(1);
       verify(config.mockRepo.getOldObjects(any)).called(1);
-      verify(config.mockRepo.deleteAll(argThat(contains(cacheObject.id))))
-          .called(1);
+      verify(config.mockRepo.deleteAll(argThat(contains(cacheObject.id)))).called(1);
     });
 
     test('Store should recheck cache info when file is removed', () async {
@@ -280,20 +282,16 @@ void main() {
         validTill: clock.now().add(const Duration(days: 7)),
       );
 
-      when(config.mockRepo.getObjectsOverCapacity(any))
-          .thenAnswer((_) => Future.value([]));
-      when(config.mockRepo.getOldObjects(any))
-          .thenAnswer((_) => Future.value([]));
-      when(config.mockRepo.get('baseflow.com/test.png'))
-          .thenAnswer((_) => Future.value(cacheObject));
+      when(config.mockRepo.getObjectsOverCapacity(any)).thenAnswer((_) => Future.value([]));
+      when(config.mockRepo.getOldObjects(any)).thenAnswer((_) => Future.value([]));
+      when(config.mockRepo.get('baseflow.com/test.png')).thenAnswer((_) => Future.value(cacheObject));
 
       expect(await store.getFile('baseflow.com/test.png'), isNotNull);
       await file.delete();
       expect(await store.getFile('baseflow.com/test.png'), isNull);
     });
 
-    test('Store should not remove files that are not old or over capacity',
-        () async {
+    test('Store should not remove files that are not old or over capacity', () async {
       var config = createTestConfig();
       var store = CacheStore(config);
       store.cleanupRunMinInterval = const Duration(milliseconds: 1);
@@ -306,12 +304,9 @@ void main() {
         validTill: clock.now().add(const Duration(days: 7)),
       );
 
-      when(config.mockRepo.getObjectsOverCapacity(any))
-          .thenAnswer((_) => Future.value([]));
-      when(config.mockRepo.getOldObjects(any))
-          .thenAnswer((_) => Future.value([]));
-      when(config.mockRepo.get('baseflow.com/test.png'))
-          .thenAnswer((_) => Future.value(cacheObject));
+      when(config.mockRepo.getObjectsOverCapacity(any)).thenAnswer((_) => Future.value([]));
+      when(config.mockRepo.getOldObjects(any)).thenAnswer((_) => Future.value([]));
+      when(config.mockRepo.get('baseflow.com/test.png')).thenAnswer((_) => Future.value(cacheObject));
 
       expect(await store.getFile('baseflow.com/test.png'), isNotNull);
 
@@ -346,13 +341,11 @@ void main() {
         validTill: clock.now().add(const Duration(days: 7)),
       );
 
-      when(config.mockRepo.getAllObjects())
-          .thenAnswer((_) => Future.value([co1, co2, co3]));
+      when(config.mockRepo.getAllObjects()).thenAnswer((_) => Future.value([co1, co2, co3]));
 
       await store.emptyCache();
 
-      verify(config.mockRepo
-          .deleteAll(argThat(containsAll([co1.id, co2.id, co3.id])))).called(1);
+      verify(config.mockRepo.deleteAll(argThat(containsAll([co1.id, co2.id, co3.id])))).called(1);
     });
   });
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce?
Feature

### :arrow_heading_down: What is the current behavior?
No way of knowing if a key is in the memory cache.

### :new: What is the new behavior (if this is a feature change)?
New method to know if a given key is present in the memory cache

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Unit tests were added - there's not much to test really, it's a really simple new method.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
