### PR TITLE
Handling redirect manually

### DIFF
--- a/flutter_cache_manager/lib/src/web/file_service.dart
+++ b/flutter_cache_manager/lib/src/web/file_service.dart
@@ -32,9 +32,15 @@ class HttpFileService extends FileService {
     if (headers != null) {
       req.headers.addAll(headers);
     }
-    final httpResponse = await _httpClient.send(req);
+    req.followRedirects = false;
+    final httpResponse = HttpGetResponse(await _httpClient.send(req));
+    final location = httpResponse._header('location');
 
-    return HttpGetResponse(httpResponse);
+    if (httpResponse.statusCode == 302 && location != null) {
+      return get(location);
+    } else {
+      return httpResponse;
+    }
   }
 }
 

--- a/flutter_cache_manager/lib/src/web/file_service.dart
+++ b/flutter_cache_manager/lib/src/web/file_service.dart
@@ -26,9 +26,12 @@ class HttpFileService extends FileService {
       : _httpClient = httpClient ?? http.Client();
 
   @override
-  Future<FileServiceResponse> get(String url,
-      {Map<String, String>? headers}) async {
-    final req = http.Request('GET', Uri.parse(url));
+  Future<FileServiceResponse> get(
+    String url, {
+    Map<String, String>? headers,
+  }) async {
+    final uri = Uri.parse(url);
+    final req = http.Request('GET', uri);
     if (headers != null) {
       req.headers.addAll(headers);
     }
@@ -37,7 +40,12 @@ class HttpFileService extends FileService {
     final location = httpResponse._header('location');
 
     if (httpResponse.statusCode == 302 && location != null) {
-      return get(location);
+      final redirectUri = Uri.parse(location);
+      if (uri.host == redirectUri.host) {
+        return get(location, headers: headers);
+      } else {
+        return get(location);
+      }
     } else {
       return httpResponse;
     }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix 

### :arrow_heading_down: What is the current behavior?
when redirect request occurs, the headers are always sent along with it

### :new: What is the new behavior (if this is a feature change)?
when redirect request occurs, the headers will be sent along with it when the hosts are the same

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
https://github.com/Baseflow/flutter_cached_network_image/issues/494
https://github.com/flutter/flutter/issues/34894

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
