### PR TITLE
access_to_cache_store_via_external_part

### DIFF
--- a/flutter_cache_manager/lib/flutter_cache_manager.dart
+++ b/flutter_cache_manager/lib/flutter_cache_manager.dart
@@ -1,4 +1,5 @@
 export 'src/cache_manager.dart';
+export 'src/cache_store.dart';
 export 'src/cache_managers/cache_managers.dart';
 export 'src/compat/file_fetcher.dart';
 export 'src/config/config.dart';

--- a/flutter_cache_manager/lib/src/cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_manager.dart
@@ -4,7 +4,6 @@ import 'dart:typed_data';
 import 'package:file/file.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
-import 'package:flutter_cache_manager/src/cache_store.dart';
 import 'package:flutter_cache_manager/src/storage/cache_object.dart';
 import 'package:flutter_cache_manager/src/web/web_helper.dart';
 import 'package:uuid/uuid.dart';

--- a/flutter_cache_manager/lib/src/cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_manager.dart
@@ -35,7 +35,6 @@ class CacheManager implements BaseCacheManager {
     _webHelper = WebHelper(_store, config.fileService);
   }
 
-  @visibleForTesting
   CacheManager.custom(
     Config config, {
     CacheStore? cacheStore,

--- a/flutter_cache_manager/lib/src/web/web_helper.dart
+++ b/flutter_cache_manager/lib/src/web/web_helper.dart
@@ -5,7 +5,6 @@ import 'dart:io';
 import 'package:clock/clock.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
-import 'package:flutter_cache_manager/src/cache_store.dart';
 import 'package:flutter_cache_manager/src/storage/cache_object.dart';
 import 'package:flutter_cache_manager/src/web/queue_item.dart';
 import 'package:rxdart/rxdart.dart';

--- a/flutter_cache_manager/test/cache_manager_test.dart
+++ b/flutter_cache_manager/test/cache_manager_test.dart
@@ -4,7 +4,6 @@ import 'dart:typed_data';
 import 'package:clock/clock.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
-import 'package:flutter_cache_manager/src/cache_store.dart';
 import 'package:flutter_cache_manager/src/storage/cache_object.dart';
 import 'package:flutter_cache_manager/src/web/web_helper.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/flutter_cache_manager/test/mock.dart
+++ b/flutter_cache_manager/test/mock.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
-import 'package:flutter_cache_manager/src/cache_store.dart';
 import 'package:flutter_cache_manager/src/web/web_helper.dart';
 import 'package:mockito/annotations.dart';
 

--- a/flutter_cache_manager/test/web_helper_test.dart
+++ b/flutter_cache_manager/test/web_helper_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:clock/clock.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
-import 'package:flutter_cache_manager/src/cache_store.dart';
 import 'package:flutter_cache_manager/src/storage/cache_object.dart';
 import 'package:flutter_cache_manager/src/web/web_helper.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Some changed export file

### :arrow_heading_down: What is the current behavior?
The behaviour is the same, except the ability to access cache_store from external code.

### :boom: Does this PR introduce a breaking change?
No, it doesn't have

### :bug: The main goal of changes
The need to modify cache_manager and use the full feature of it factory CacheManager.custom to change the CacheStore and some of its abilities. This is necessary, to except saving images to the database and save, if necessary, only in the RAM memory. Ask to allow me to apply this change.