### PR TITLE
fix example app baseflow git url

### DIFF
--- a/flutter_cache_manager/example/pubspec.yaml
+++ b/flutter_cache_manager/example/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   baseflow_plugin_template:
     git:
-      url: git://github.com/Baseflow/baseflow_plugin_template.git
+      url: https://github.com/Baseflow/baseflow_plugin_template.git
       ref: v1.0.0
   cupertino_icons: ^1.0.2
   flutter:


### PR DESCRIPTION
Signed-off-by: Ritesh Khadse <r.khadse@flick2know.com>

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
fix for #367 
fix git url in example app of flutter_cache_manager 

### :arrow_heading_down: What is the current behavior?
currently on running the command `flutter pub get` I was getting 

`fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
exit code: 128`

reference of fix:
https://stackoverflow.com/questions/70663523/the-unauthenticated-git-protocol-on-port-9418-is-no-longer-supported

### :new: What is the new behavior (if this is a feature change)?

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
