### PR TITLE
Add config getter to CacheManager

### DIFF
--- a/flutter_cache_manager/lib/src/cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_manager.dart
@@ -48,6 +48,9 @@ class CacheManager implements BaseCacheManager {
 
   final Config _config;
 
+  /// Get the config
+  Config get config => _config;
+
   /// Store helper for cached files
   final CacheStore _store;
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature


### :arrow_heading_down: What is the current behavior?
`CacheManager.config` isn't accessible


### :new: What is the new behavior (if this is a feature change)?
I added a `CacheManager.config` getter allowing to read config.

### :boom: Does this PR introduce a breaking change?
No


### :bug: Recommendations for testing
This is quite simple, shouldn't require much testing. 

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
