### PR TITLE
Update links for pub.dev

### DIFF
--- a/flutter_cache_manager/pubspec.yaml
+++ b/flutter_cache_manager/pubspec.yaml
@@ -1,7 +1,8 @@
 name: flutter_cache_manager
 description: Generic cache manager for flutter. Saves web files on the storages of the device and saves the cache info using sqflite.
 version: 3.3.0
-homepage: https://github.com/Baseflow/flutter_cache_manager/tree/master/flutter_cache_manager
+repository: https://github.com/Baseflow/flutter_cache_manager/tree/master/flutter_cache_manager
+issue_tracker: https://github.com/Baseflow/flutter_cache_manager/issues
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

With this PR, the right section on pub.dev will show the View/report issues link to GitHub again, like [here](https://pub.dev/packages/android_id) (the show-logic was recently changed).


### :arrow_heading_down: What is the current behavior?

It shows a `Homepage` link


### :new: What is the new behavior (if this is a feature change)?

It shows links to `Repository (GitHub)` and `View/report issues`


### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
