### PR TITLE
Fixed: PathNotFoundException when deleting a file that is already del…

### DIFF
--- a/flutter_cache_manager/lib/src/cache_store.dart
+++ b/flutter_cache_manager/lib/src/cache_store.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'dart:io' as io;
@@ -185,7 +186,12 @@ class CacheStore {
     final file = io.File(cacheObject.relativePath);
 
     if (file.existsSync()) {
-      await file.delete();
+      try {
+        await file.delete();
+        // ignore: unused_catch_clause
+      } on PathNotFoundException catch (e) {
+        // File has already been deleted. Do nothing #184
+      }
     }
   }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug Fix https://github.com/Baseflow/flutter_cache_manager/issues/184


### :arrow_heading_down: What is the current behavior?
Throws PathNotFoundException when deleting files that are already deleted

### :new: What is the new behavior (if this is a feature change)?
Ignore Error

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
https://github.com/Baseflow/flutter_cache_manager/issues/184

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
