### PR TITLE
Export File System

### DIFF
--- a/flutter_cache_manager/lib/flutter_cache_manager.dart
+++ b/flutter_cache_manager/lib/flutter_cache_manager.dart
@@ -10,5 +10,6 @@ export 'src/logger.dart';
 export 'src/result/result.dart';
 export 'src/storage/cache_info_repositories/cache_info_repositories.dart';
 export 'src/storage/cache_object.dart';
+export 'src/storage/file_system/file_system.dart';
 export 'src/web/file_service.dart';
 export 'src/web/web_helper.dart' show HttpExceptionWithStatus;

--- a/flutter_cache_manager/lib/src/cache_store.dart
+++ b/flutter_cache_manager/lib/src/cache_store.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'dart:io' as io;
-import 'package:flutter_cache_manager/src/storage/file_system/file_system.dart';
 
 ///Flutter Cache Manager
 ///Copyright (c) 2019 Rene Floor

--- a/flutter_cache_manager/lib/src/config/_config_io.dart
+++ b/flutter_cache_manager/lib/src/config/_config_io.dart
@@ -2,8 +2,6 @@ import 'dart:io';
 
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_cache_manager/src/config/config.dart' as def;
-import 'package:flutter_cache_manager/src/storage/file_system/file_system.dart';
-import 'package:flutter_cache_manager/src/storage/file_system/file_system_io.dart';
 
 class Config implements def.Config {
   Config(

--- a/flutter_cache_manager/lib/src/config/_config_web.dart
+++ b/flutter_cache_manager/lib/src/config/_config_web.dart
@@ -2,7 +2,6 @@ import 'package:flutter_cache_manager/src/config/config.dart' as def;
 import 'package:flutter_cache_manager/src/storage/cache_info_repositories/cache_info_repository.dart';
 import 'package:flutter_cache_manager/src/storage/cache_info_repositories/non_storing_object_provider.dart';
 import 'package:flutter_cache_manager/src/storage/file_system/file_system.dart';
-import 'package:flutter_cache_manager/src/storage/file_system/file_system_web.dart';
 import 'package:flutter_cache_manager/src/web/file_service.dart';
 
 class Config implements def.Config {

--- a/flutter_cache_manager/lib/src/config/config.dart
+++ b/flutter_cache_manager/lib/src/config/config.dart
@@ -2,7 +2,6 @@ import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_cache_manager/src/config/_config_unsupported.dart'
     if (dart.library.html) '_config_web.dart'
     if (dart.library.io) '_config_io.dart' as impl;
-import 'package:flutter_cache_manager/src/storage/file_system/file_system.dart';
 
 abstract class Config {
   /// Config file for the CacheManager.

--- a/flutter_cache_manager/lib/src/storage/file_system/file_system.dart
+++ b/flutter_cache_manager/lib/src/storage/file_system/file_system.dart
@@ -1,3 +1,7 @@
+export 'file_system.dart';
+export 'file_system_io.dart';
+export 'file_system_web.dart';
+
 import 'package:file/file.dart';
 
 abstract class FileSystem {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
feature

### :arrow_heading_down: What is the current behavior?
The FileSystem, IOFileSystem and MemoryCacheSystem can't be imported like code below.
``` dart
import 'package:flutter_cache_manager/flutter_cache_manager.dart';

class CustomCacheManager {
  static const key = 'customCacheKey';
  static CacheManager instance = CacheManager(
    Config(
      key,
      stalePeriod: const Duration(days: 7),
      maxNrOfCacheObjects: 20,
      repo: JsonCacheInfoRepository(databaseName: key),
      fileSystem: IOFileSystem(key),
      fileService: HttpFileService(),
    ),
  );
}
```

### :new: What is the new behavior (if this is a feature change)?
The FileSystem, IOFileSystem and MemoryCacheSystem can be imported

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
1. update pubspec.yaml
``` yaml
  flutter_cache_manager:
    git:
      url: https://github.com/wyyadd/flutter_cache_manager
      path: flutter_cache_manager
```
2. run __flutter pub get__
3. run code below to test
``` dart
import 'package:flutter_cache_manager/flutter_cache_manager.dart';

class CustomCacheManager {
  static const key = 'customCacheKey';
  static CacheManager instance = CacheManager(
    Config(
      key,
      stalePeriod: const Duration(days: 7),
      maxNrOfCacheObjects: 20,
      repo: JsonCacheInfoRepository(databaseName: key),
      fileSystem: IOFileSystem(key),
      fileService: HttpFileService(),
    ),
  );
}
```

### :memo: Links to relevant issues/docs
https://github.com/Baseflow/flutter_cache_manager/issues/365

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop

### Proposal
> Please consider using `getApplicationCachePath()` introduced in path_provider 2.1.0:
> 
> * [[path_provider] Add getApplicationCachePath() flutter/packages#4483](https://github.com/flutter/packages/pull/4483)
> 
> Notice that /tmp may be unsuitable for caching on systems with multiple users. For example, run the [cached_network_image](https://pub.dev/packages/cached_network_image) example first as user A and then as user B on Ubuntu:
> 
> ```
> PathAccessException: Cannot open file, path = '/tmp/libCachedImageData/dc555ac0-23b8-11ee-8203-690c79df21e0.jpg' (OS Error: Permission denied, errno = 13)
> Another exception was thrown: PathAccessException: Cannot open file, path =
> '/tmp/libCachedImageData/dc555ac0-23b8-11ee-8203-690c79df21e0.jpg' (OS Error: Permission denied, errno = 13)
> flutter: CacheManager: Failed to download file from https://notAvalid.uri with error:
> ClientException with SocketException: Failed host lookup: 'notavalid.uri' (OS Error: No address associated with hostname, errno = -5), uri=https://notavalid.uri
> flutter: CacheManager: Failed to download file from https://via.placeholder.com/300x150 with error:
> PathAccessException: Cannot open file, path = '/tmp/libCachedImageData/dc854460-23b8-11ee-8203-690c79df21e0.png' (OS Error: Permission denied, errno = 13)
> flutter: CacheManager: Failed to download file from https://via.placeholder.com/200x150 with error:
> PathAccessException: Cannot open file, path = '/tmp/libCachedImageData/dc854461-23b8-11ee-8203-690c79df21e0.png' (OS Error: Permission denied, errno = 13)
> flutter: CacheManager: Failed to download file from https://via.placeholder.com/350x200 with error:
> PathAccessException: Cannot open file, path = '/tmp/libCachedImageData/dc854462-23b8-11ee-8203-690c79df21e0.png' (OS Error: Permission denied, errno = 13)
> Another exception was thrown: PathAccessException: Cannot open file, path =
> '/tmp/libCachedImageData/dc854461-23b8-11ee-8203-690c79df21e0.png' (OS Error: Permission denied, errno = 13)
> flutter: CacheManager: Failed to download file from https://via.placeholder.com/350x150 with error:
> PathAccessException: Cannot open file, path = '/tmp/libCachedImageData/dc856b70-23b8-11ee-8203-690c79df21e0.png' (OS Error: Permission denied, errno = 13)
> flutter: CacheManager: Failed to download file from https://via.placeholder.com/300x300 with error:
> PathAccessException: Cannot open file, path = '/tmp/libCachedImageData/dc856b71-23b8-11ee-8203-690c79df21e0.png' (OS Error: Permission denied, errno = 13)
> Another exception was thrown: PathAccessException: Cannot open file, path =
> '/tmp/libCachedImageData/dc856b70-23b8-11ee-8203-690c79df21e0.png' (OS Error: Permission denied, errno = 13)
> Another exception was thrown: PathAccessException: Cannot open file, path =
> '/tmp/libCachedImageData/dc856b71-23b8-11ee-8203-690c79df21e0.png' (OS Error: Permission denied, errno = 13)
> ```

For flutter desktop, it would be better to use getApplicationCacheDirectory() instead of getTemporaryDirectory() to create directory. 
Relevant issue: https://github.com/Baseflow/flutter_cache_manager/issues/416
