### PR TITLE
Fix #436 - Evict on 404 and notify listeners

### DIFF
--- a/flutter_cache_manager/CHANGELOG.md
+++ b/flutter_cache_manager/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [3.3.2] - 2023-12-05
+* [Bugfix] For a previously cached file that got removed on the server, now evicts that file on 404 and notifies listeners.
+
 ## [3.3.1] - 2023-07-03
 * Support Dart 3.0.0 for http ^1.0.0 and file ^7.0.0
 * Update example

--- a/flutter_cache_manager/lib/src/cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_manager.dart
@@ -149,8 +149,11 @@ class CacheManager implements BaseCacheManager {
         cacheLogger.log(
             'CacheManager: Failed to download file from $url with error:\n$e',
             CacheManagerLogLevel.debug);
-        if (cacheFile == null && streamController.hasListener) {
+        if (streamController.hasListener) {
           streamController.addError(e);
+        }
+        if (cacheFile != null) {
+          await removeFile(key);
         }
       }
     }

--- a/flutter_cache_manager/lib/src/cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_manager.dart
@@ -154,7 +154,9 @@ class CacheManager implements BaseCacheManager {
         }
 
         if (cacheFile != null && e is HttpExceptionWithStatus && e.statusCode == 404) {
-          streamController.addError(e);
+          if (streamController.hasListener) {
+            streamController.addError(e);
+          }
           await removeFile(key);
         }
       }

--- a/flutter_cache_manager/lib/src/cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_manager.dart
@@ -149,10 +149,12 @@ class CacheManager implements BaseCacheManager {
         cacheLogger.log(
             'CacheManager: Failed to download file from $url with error:\n$e',
             CacheManagerLogLevel.debug);
-        if (streamController.hasListener) {
+        if (cacheFile == null && streamController.hasListener) {
           streamController.addError(e);
         }
-        if (cacheFile != null) {
+
+        if (cacheFile != null && e is HttpExceptionWithStatus && e.statusCode == 404) {
+          streamController.addError(e);
           await removeFile(key);
         }
       }

--- a/flutter_cache_manager/pubspec.yaml
+++ b/flutter_cache_manager/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_cache_manager
 description: Generic cache manager for flutter. Saves web files on the storages of the device and saves the cache info using sqflite.
-version: 3.3.1
+version: 3.3.2
 homepage: https://github.com/Baseflow/flutter_cache_manager/tree/develop/flutter_cache_manager
 topics:
   - cache

--- a/flutter_cache_manager/test/cache_manager_test.dart
+++ b/flutter_cache_manager/test/cache_manager_test.dart
@@ -151,10 +151,13 @@ void main() {
       when(store.getFile(fileUrl)).thenAnswer((_) => Future.value(cachedInfo));
 
       var webHelper = MockWebHelper();
-      var downloadedInfo = FileInfo(file, FileSource.Online, DateTime.now().add(const Duration(days: 1)), fileUrl);
-      when(webHelper.downloadFile(fileUrl, key: anyNamed('key'))).thenAnswer((_) => Stream.value(downloadedInfo));
+      var downloadedInfo = FileInfo(file, FileSource.Online,
+          DateTime.now().add(const Duration(days: 1)), fileUrl);
+      when(webHelper.downloadFile(fileUrl, key: anyNamed('key')))
+          .thenAnswer((_) => Stream.value(downloadedInfo));
 
-      var cacheManager = TestCacheManager(createTestConfig(), store: store, webHelper: webHelper);
+      var cacheManager = TestCacheManager(createTestConfig(),
+          store: store, webHelper: webHelper);
 
       // ignore: deprecated_member_use_from_same_package
       var fileStream = cacheManager.getFile(fileUrl);
@@ -175,7 +178,8 @@ void main() {
       when(store.getFile(fileUrl)).thenAnswer((_) => Future.value(null));
 
       var webHelper = MockWebHelper();
-      when(webHelper.downloadFile(fileUrl, key: anyNamed('key'))).thenAnswer((_) => Stream.value(fileInfo));
+      when(webHelper.downloadFile(fileUrl, key: anyNamed('key')))
+          .thenAnswer((_) => Stream.value(fileInfo));
 
       var cacheManager = TestCacheManager(
         createTestConfig(),
@@ -196,8 +200,10 @@ void main() {
       when(store.getFile(fileUrl)).thenAnswer((_) => Future.value(null));
 
       var webHelper = MockWebHelper();
-      var error = HttpExceptionWithStatus(404, 'Invalid statusCode: 404', uri: Uri.parse(fileUrl));
-      when(webHelper.downloadFile(fileUrl, key: anyNamed('key'))).thenThrow(error);
+      var error = HttpExceptionWithStatus(404, 'Invalid statusCode: 404',
+          uri: Uri.parse(fileUrl));
+      when(webHelper.downloadFile(fileUrl, key: anyNamed('key')))
+          .thenThrow(error);
 
       var cacheManager = TestCacheManager(
         createTestConfig(),
@@ -303,7 +309,8 @@ void main() {
       var store = MockCacheStore();
       var cacheManager = TestCacheManager(createTestConfig(), store: store);
 
-      var file = await cacheManager.putFile(fileUrl, fileBytes, fileExtension: extension);
+      var file = await cacheManager.putFile(fileUrl, fileBytes,
+          fileExtension: extension);
       expect(await file.exists(), true);
       expect(await file.readAsBytes(), fileBytes);
       verify(store.putFile(any)).called(1);
@@ -318,10 +325,12 @@ void main() {
       var store = MockCacheStore();
       var cacheManager = TestCacheManager(createTestConfig(), store: store);
 
-      var file = await cacheManager.putFile(fileUrl, fileBytes, key: fileKey, fileExtension: extension);
+      var file = await cacheManager.putFile(fileUrl, fileBytes,
+          key: fileKey, fileExtension: extension);
       expect(await file.exists(), true);
       expect(await file.readAsBytes(), fileBytes);
-      final arg = verify(store.putFile(captureAny)).captured.first as CacheObject;
+      final arg =
+          verify(store.putFile(captureAny)).captured.first as CacheObject;
       expect(arg.key, fileKey);
       expect(arg.url, fileUrl);
     });
@@ -329,7 +338,8 @@ void main() {
     test('Check if file is written and info is stored', () async {
       var fileUrl = 'baseflow.com/test';
       var extension = 'jpg';
-      var memorySystem = await MemoryFileSystem().systemTempDirectory.createTemp('origin');
+      var memorySystem =
+          await MemoryFileSystem().systemTempDirectory.createTemp('origin');
 
       var existingFile = memorySystem.childFile('testfile.jpg');
       var fileBytes = Uint8List(16);
@@ -338,7 +348,9 @@ void main() {
       var store = MockCacheStore();
       var cacheManager = TestCacheManager(createTestConfig(), store: store);
 
-      var file = await cacheManager.putFileStream(fileUrl, existingFile.openRead(), fileExtension: extension);
+      var file = await cacheManager.putFileStream(
+          fileUrl, existingFile.openRead(),
+          fileExtension: extension);
       expect(await file.exists(), true);
       expect(await file.readAsBytes(), fileBytes);
       verify(store.putFile(any)).called(1);
@@ -348,7 +360,8 @@ void main() {
       var fileUrl = 'baseflow.com/test';
       var fileKey = 'test1234';
       var extension = 'jpg';
-      var memorySystem = await MemoryFileSystem().systemTempDirectory.createTemp('origin');
+      var memorySystem =
+          await MemoryFileSystem().systemTempDirectory.createTemp('origin');
 
       var existingFile = memorySystem.childFile('testfile.jpg');
       var fileBytes = Uint8List(16);
@@ -357,11 +370,13 @@ void main() {
       var store = MockCacheStore();
       var cacheManager = TestCacheManager(createTestConfig(), store: store);
 
-      var file =
-          await cacheManager.putFileStream(fileUrl, existingFile.openRead(), key: fileKey, fileExtension: extension);
+      var file = await cacheManager.putFileStream(
+          fileUrl, existingFile.openRead(),
+          key: fileKey, fileExtension: extension);
       expect(await file.exists(), true);
       expect(await file.readAsBytes(), fileBytes);
-      final arg = verify(store.putFile(captureAny)).captured.first as CacheObject;
+      final arg =
+          verify(store.putFile(captureAny)).captured.first as CacheObject;
       expect(arg.key, fileKey);
       expect(arg.url, fileUrl);
     });
@@ -372,12 +387,13 @@ void main() {
       var fileUrl = 'baseflow.com/test';
 
       var store = MockCacheStore();
-      when(store.retrieveCacheData(fileUrl)).thenAnswer((_) => Future.value(CacheObject(
-            fileUrl,
-            relativePath: 'test.png',
-            validTill: clock.now(),
-            id: 123,
-          )));
+      when(store.retrieveCacheData(fileUrl))
+          .thenAnswer((_) => Future.value(CacheObject(
+                fileUrl,
+                relativePath: 'test.png',
+                validTill: clock.now(),
+                id: 123,
+              )));
 
       var cacheManager = TestCacheManager(createTestConfig(), store: store);
 
@@ -389,7 +405,8 @@ void main() {
       var fileUrl = 'baseflow.com/test';
 
       var store = MockCacheStore();
-      when(store.retrieveCacheData(fileUrl)).thenAnswer((_) => Future.value(null));
+      when(store.retrieveCacheData(fileUrl))
+          .thenAnswer((_) => Future.value(null));
 
       var cacheManager = TestCacheManager(createTestConfig(), store: store);
 
@@ -401,12 +418,13 @@ void main() {
       var fileUrl = 'baseflow.com/test';
 
       var store = MockCacheStore();
-      when(store.retrieveCacheData(fileUrl)).thenAnswer((_) => Future.value(CacheObject(
-            fileUrl,
-            relativePath: 'test.png',
-            validTill: clock.now(),
-            id: null,
-          )));
+      when(store.retrieveCacheData(fileUrl))
+          .thenAnswer((_) => Future.value(CacheObject(
+                fileUrl,
+                relativePath: 'test.png',
+                validTill: clock.now(),
+                id: null,
+              )));
 
       var cacheManager = TestCacheManager(createTestConfig(), store: store);
 
@@ -418,10 +436,12 @@ void main() {
 
   test('Download file just downloads file', () async {
     var fileUrl = 'baseflow.com/test';
-    var fileInfo = FileInfo(MemoryFileSystem.test().file('f'), FileSource.Cache, DateTime.now(), fileUrl);
+    var fileInfo = FileInfo(MemoryFileSystem.test().file('f'), FileSource.Cache,
+        DateTime.now(), fileUrl);
     var store = MockCacheStore();
     var webHelper = MockWebHelper();
-    when(webHelper.downloadFile(fileUrl, key: anyNamed('key'))).thenAnswer((_) => Stream.value(fileInfo));
+    when(webHelper.downloadFile(fileUrl, key: anyNamed('key')))
+        .thenAnswer((_) => Stream.value(fileInfo));
     var cacheManager = TestCacheManager(
       createTestConfig(),
       webHelper: webHelper,
@@ -432,12 +452,15 @@ void main() {
 
   test('test file from memory', () async {
     var fileUrl = 'baseflow.com/test';
-    var fileInfo = FileInfo(MemoryFileSystem.test().file('f'), FileSource.Cache, DateTime.now(), fileUrl);
+    var fileInfo = FileInfo(MemoryFileSystem.test().file('f'), FileSource.Cache,
+        DateTime.now(), fileUrl);
 
     var store = MockCacheStore();
-    when(store.getFileFromMemory(fileUrl)).thenAnswer((realInvocation) async => fileInfo);
+    when(store.getFileFromMemory(fileUrl))
+        .thenAnswer((realInvocation) async => fileInfo);
     var webHelper = MockWebHelper();
-    var cacheManager = TestCacheManager(createTestConfig(), store: store, webHelper: webHelper);
+    var cacheManager = TestCacheManager(createTestConfig(),
+        store: store, webHelper: webHelper);
     var result = await cacheManager.getFileFromMemory(fileUrl);
     expect(result, fileInfo);
   });
@@ -456,9 +479,15 @@ void main() {
       var config = createTestConfig();
       var fileService = config.fileService;
       var downloadStreamController = StreamController<List<int>>();
-      when(fileService.get(fileUrl, headers: anyNamed('headers'))).thenAnswer((_) {
-        return Future.value(
-            MockFileFetcherResponse(downloadStreamController.stream, 6, 'testv1', '.jpg', 200, DateTime.now()));
+      when(fileService.get(fileUrl, headers: anyNamed('headers')))
+          .thenAnswer((_) {
+        return Future.value(MockFileFetcherResponse(
+            downloadStreamController.stream,
+            6,
+            'testv1',
+            '.jpg',
+            200,
+            DateTime.now()));
       });
 
       var cacheManager = TestCacheManager(config);
@@ -493,9 +522,15 @@ void main() {
       when(store.getFile(fileUrl)).thenAnswer((_) => Future.value(null));
 
       var downloadStreamController = StreamController<List<int>>();
-      when(config.fileService.get(fileUrl, headers: anyNamed('headers'))).thenAnswer((_) {
-        return Future.value(
-            MockFileFetcherResponse(downloadStreamController.stream, 6, 'testv1', '.jpg', 200, DateTime.now()));
+      when(config.fileService.get(fileUrl, headers: anyNamed('headers')))
+          .thenAnswer((_) {
+        return Future.value(MockFileFetcherResponse(
+            downloadStreamController.stream,
+            6,
+            'testv1',
+            '.jpg',
+            200,
+            DateTime.now()));
       });
 
       var cacheManager = TestCacheManager(config);
@@ -523,5 +558,6 @@ class TestCacheManager extends CacheManager with ImageCacheManager {
     Config? config, {
     CacheStore? store,
     WebHelper? webHelper,
-  }) : super.custom(config ?? createTestConfig(), cacheStore: store, webHelper: webHelper);
+  }) : super.custom(config ?? createTestConfig(),
+            cacheStore: store, webHelper: webHelper);
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

- Adds bugfix for #436
- Adds a test `Outdated cacheFile should call to web, where 404 response should add Error to Stream and evict cache`

### :arrow_heading_down: What is the current behavior?

- On an existing `cacheFile` and 404 on the update, listeners are not notified of the 404, and the file is not evicted.

### :new: What is the new behavior (if this is a feature change)?

- On 404 only, adds error to stream for existing cache file and evicts file


### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Includes test

### :memo: Links to relevant issues/docs

#436 

also see https://github.com/Baseflow/flutter_cached_network_image/issues/898 for some related issues

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [x] ~~Relevant documentation was updated~~~
  - no documentation change needed
- [x] Rebased onto current develop
