### PR TITLE
feat: Allowing caching of 404 responses

### DIFF
--- a/flutter_cache_manager/example/lib/plugin_example/file_info_widget.dart
+++ b/flutter_cache_manager/example/lib/plugin_example/file_info_widget.dart
@@ -24,7 +24,7 @@ class FileInfoWidget extends StatelessWidget {
         ),
         ListTile(
           title: const Text('Local file path'),
-          subtitle: Text(fileInfo.file.path),
+          subtitle: Text(fileInfo.file?.path ?? 'Not found'),
         ),
         ListTile(
           title: const Text('Loaded from'),

--- a/flutter_cache_manager/lib/src/cache_managers/base_cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_managers/base_cache_manager.dart
@@ -12,7 +12,7 @@ abstract class BaseCacheManager {
   /// When a file is cached it is return directly, when it is too old the file is
   /// downloaded in the background. When a cached file is not available the
   /// newly downloaded file is returned.
-  Future<File> getSingleFile(
+  Future<File?> getSingleFile(
     String url, {
     String key,
     Map<String, String> headers,
@@ -57,7 +57,7 @@ abstract class BaseCacheManager {
   /// for example "jpg". When cache info is available for the url that path
   /// is re-used.
   /// The returned [File] is saved on disk.
-  Future<File> putFile(
+  Future<File?> putFile(
     String url,
     Uint8List fileBytes, {
     String? key,
@@ -73,7 +73,7 @@ abstract class BaseCacheManager {
   /// for example "jpg". When cache info is available for the url that path
   /// is re-used.
   /// The returned [File] is saved on disk.
-  Future<File> putFileStream(
+  Future<File?> putFileStream(
     String url,
     Stream<List<int>> source, {
     String? key,

--- a/flutter_cache_manager/lib/src/config/_config_io.dart
+++ b/flutter_cache_manager/lib/src/config/_config_io.dart
@@ -10,11 +10,13 @@ class Config implements def.Config {
     this.cacheKey, {
     Duration? stalePeriod,
     int? maxNrOfCacheObjects,
+    bool? cache404Responses,
     CacheInfoRepository? repo,
     FileSystem? fileSystem,
     FileService? fileService,
   })  : stalePeriod = stalePeriod ?? const Duration(days: 30),
         maxNrOfCacheObjects = maxNrOfCacheObjects ?? 200,
+        cache404Responses = cache404Responses ?? false,
         repo = repo ?? _createRepo(cacheKey),
         fileSystem = fileSystem ?? IOFileSystem(cacheKey),
         fileService = fileService ?? HttpFileService();
@@ -33,6 +35,9 @@ class Config implements def.Config {
 
   @override
   final int maxNrOfCacheObjects;
+
+  @override
+  final bool cache404Responses;
 
   @override
   final FileService fileService;

--- a/flutter_cache_manager/lib/src/config/_config_unsupported.dart
+++ b/flutter_cache_manager/lib/src/config/_config_unsupported.dart
@@ -13,6 +13,8 @@ class Config implements def.Config {
     //ignore: avoid_unused_constructor_parameters
     int? maxNrOfCacheObjects,
     //ignore: avoid_unused_constructor_parameters
+    bool? cache404Responses,
+    //ignore: avoid_unused_constructor_parameters
     CacheInfoRepository? repo,
     //ignore: avoid_unused_constructor_parameters
     FileSystem? fileSystem,
@@ -36,6 +38,9 @@ class Config implements def.Config {
 
   @override
   int get maxNrOfCacheObjects => throw UnimplementedError();
+
+  @override
+  bool get cache404Responses => throw UnimplementedError();
 
   @override
   FileService get fileService => throw UnimplementedError();

--- a/flutter_cache_manager/lib/src/config/_config_web.dart
+++ b/flutter_cache_manager/lib/src/config/_config_web.dart
@@ -10,11 +10,13 @@ class Config implements def.Config {
     this.cacheKey, {
     Duration? stalePeriod,
     int? maxNrOfCacheObjects,
+    bool? cache404Responses,
     CacheInfoRepository? repo,
     FileSystem? fileSystem,
     FileService? fileService,
   })  : stalePeriod = stalePeriod ?? const Duration(days: 30),
         maxNrOfCacheObjects = maxNrOfCacheObjects ?? 200,
+        cache404Responses = cache404Responses ?? false,
         repo = repo ?? NonStoringObjectProvider(),
         fileSystem = fileSystem ?? MemoryCacheSystem(),
         fileService = fileService ?? HttpFileService();
@@ -33,6 +35,9 @@ class Config implements def.Config {
 
   @override
   final int maxNrOfCacheObjects;
+
+  @override
+  final bool cache404Responses;
 
   @override
   final FileService fileService;

--- a/flutter_cache_manager/lib/src/config/config.dart
+++ b/flutter_cache_manager/lib/src/config/config.dart
@@ -14,6 +14,8 @@ abstract class Config {
   /// [maxNrOfCacheObjects] defines how large the cache is allowed to be. If
   /// there are more files the files that haven't been used for the longest
   /// time will be removed.
+  /// [cache404Responses] controls whether 404 responses are cached. The default
+  /// behaviour is to not cache 404s.
   /// [repo] is the [CacheInfoRepository] which stores the cache metadata. On
   /// Android, iOS and macOS this defaults to [CacheObjectProvider], a
   /// sqflite implementation due to legacy. On web this defaults to
@@ -25,6 +27,7 @@ abstract class Config {
     String cacheKey, {
     Duration stalePeriod,
     int maxNrOfCacheObjects,
+    bool cache404Responses,
     CacheInfoRepository repo,
     FileSystem fileSystem,
     FileService fileService,
@@ -35,6 +38,8 @@ abstract class Config {
   Duration get stalePeriod;
 
   int get maxNrOfCacheObjects;
+
+  bool get cache404Responses;
 
   CacheInfoRepository get repo;
 

--- a/flutter_cache_manager/lib/src/result/file_info.dart
+++ b/flutter_cache_manager/lib/src/result/file_info.dart
@@ -16,7 +16,7 @@ class FileInfo extends FileResponse {
       : super(originalUrl);
 
   /// Fetched file
-  final File file;
+  final File? file;
 
   /// Source from the file, can be cache or online (web).
   final FileSource source;

--- a/flutter_cache_manager/lib/src/storage/cache_object.dart
+++ b/flutter_cache_manager/lib/src/storage/cache_object.dart
@@ -30,7 +30,7 @@ class CacheObject {
       : id = map[columnId] as int,
         url = map[columnUrl] as String,
         key = map[columnKey] as String? ?? map[columnUrl] as String,
-        relativePath = map[columnPath] as String,
+        relativePath = map[columnPath] as String?,
         validTill =
             DateTime.fromMillisecondsSinceEpoch(map[columnValidTill] as int),
         eTag = map[columnETag] as String?,
@@ -49,8 +49,8 @@ class CacheObject {
   /// This key is optional and will default to [url] if not specified
   final String key;
 
-  /// Where the cached file is stored
-  final String relativePath;
+  /// Where the cached file is stored if it exists
+  final String? relativePath;
 
   /// When this cached item becomes invalid
   final DateTime validTill;
@@ -103,4 +103,15 @@ class CacheObject {
       touched: touched,
     );
   }
+
+  CacheObject withoutRelativePath() => CacheObject(
+        url,
+        id: id,
+        key: key,
+        relativePath: null,
+        validTill: validTill,
+        eTag: eTag,
+        length: length,
+        touched: touched,
+      );
 }

--- a/flutter_cache_manager/pubspec.yaml
+++ b/flutter_cache_manager/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
   sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
+  async: ^2.11.0
   clock: ^1.1.0
   collection: ^1.15.0
   file: '>=6.1.4 <8.0.0'

--- a/flutter_cache_manager/test/helpers/config_extensions.dart
+++ b/flutter_cache_manager/test/helpers/config_extensions.dart
@@ -19,7 +19,7 @@ extension ConfigExtensions on Config {
 
   void returnsCacheObject(
     String fileUrl,
-    String fileName,
+    String? fileName,
     DateTime validTill, {
     String? key,
     int? id,

--- a/flutter_cache_manager/test/image_cache_manager_test.dart
+++ b/flutter_cache_manager/test/image_cache_manager_test.dart
@@ -28,11 +28,23 @@ void main() {
       await verifySize(bytes, 120, 120);
     });
 
+    test('File should not be modified when none was saved', () async {
+      var validTill = DateTime.now().add(const Duration(days: 1));
+      var config = createTestConfig()
+        ..returnsCacheObject(fileUrl, null, validTill);
+      var cacheManager = TestCacheManager(config);
+
+      var result = await cacheManager
+          .getImageFile(fileUrl, maxWidth: 100, maxHeight: 100)
+          .last as FileInfo;
+      expect(result.file, isNull);
+    });
+
     test('File should not be modified when no height or width is given',
         () async {
       var cacheManager = await setupCacheManager();
       var result = await cacheManager.getImageFile(fileUrl).last as FileInfo;
-      var image = await result.file.readAsBytes();
+      var image = await result.file!.readAsBytes();
       await verifySize(image, 120, 120);
     });
 
@@ -44,7 +56,7 @@ void main() {
             maxHeight: 100,
           )
           .last as FileInfo;
-      var image = await result.file.readAsBytes();
+      var image = await result.file!.readAsBytes();
       await verifySize(image, 100, 100);
     });
 
@@ -56,7 +68,7 @@ void main() {
             maxWidth: 100,
           )
           .last as FileInfo;
-      var image = await result.file.readAsBytes();
+      var image = await result.file!.readAsBytes();
       await verifySize(image, 100, 100);
     });
 
@@ -66,7 +78,7 @@ void main() {
       var result = await cacheManager
           .getImageFile(fileUrl, maxWidth: 100, maxHeight: 80)
           .last as FileInfo;
-      var image = await result.file.readAsBytes();
+      var image = await result.file!.readAsBytes();
       await verifySize(image, 80, 80);
     });
   });


### PR DESCRIPTION
In some scenarious 404s are expected. Imagine a sports app which shows player images but only the most well-known players have images. In this scenario if the 404 is not cached then a lot of unnecessary requests will be made.