### PR TITLE
chore: upgrade rxdart to 0.28.0

### DIFF
--- a/flutter_cache_manager/pubspec.yaml
+++ b/flutter_cache_manager/pubspec.yaml
@@ -6,7 +6,7 @@ topics:
   - cache
   - cache-manager
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
   clock: ^1.1.0
@@ -17,7 +17,7 @@ dependencies:
   http: ^1.2.1
   path: ^1.9.0
   path_provider: ^2.1.3
-  rxdart: ^0.27.7
+  rxdart: ^0.28.0
   sqflite: ^2.3.3
   uuid: ^4.4.0
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Upgrades `rxdart` to 0.28.0 to allow apps that are depending on that version to compile.

### :arrow_heading_down: What is the current behavior?
The apps that depend on this package and on `rxdart` 0.28.0 don't compile.


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?
Yes, it will not allow apps with previous `rxdart` versions to build.

### :memo: Links to relevant issues/docs
Closes #458

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
