### PR TITLE
change order to allow to override ifNoneMatchHeader

### DIFF
--- a/flutter_cache_manager/lib/src/result/file_info.dart
+++ b/flutter_cache_manager/lib/src/result/file_info.dart
@@ -12,7 +12,8 @@ enum FileSource { NA, Cache, Online }
 /// FileInfo contains the fetch File next to some info on the validity and
 /// the origin of the file.
 class FileInfo extends FileResponse {
-  const FileInfo(this.file, this.source, this.validTill, String originalUrl)
+  const FileInfo(this.file, this.source, this.validTill, String originalUrl,
+      {this.statusCode = 200})
       : super(originalUrl);
 
   /// Fetched file
@@ -24,4 +25,6 @@ class FileInfo extends FileResponse {
   /// Validity date of the file. After this date the validity is not guaranteed
   /// and the CacheManager will try to update the file.
   final DateTime validTill;
+
+  final int statusCode;
 }

--- a/flutter_cache_manager/lib/src/web/web_helper.dart
+++ b/flutter_cache_manager/lib/src/web/web_helper.dart
@@ -100,15 +100,16 @@ class WebHelper {
   Future<FileServiceResponse> _download(
       CacheObject cacheObject, Map<String, String>? authHeaders) {
     final headers = <String, String>{};
-    if (authHeaders != null) {
-      headers.addAll(authHeaders);
-    }
 
     final etag = cacheObject.eTag;
 
     // Adding `if-none-match` header on web causes a CORS error.
     if (etag != null && !kIsWeb) {
       headers[HttpHeaders.ifNoneMatchHeader] = etag;
+    }
+
+    if (authHeaders != null) {
+      headers.addAll(authHeaders);
     }
 
     return fileFetcher.get(cacheObject.url, headers: headers);

--- a/flutter_cache_manager/lib/src/web/web_helper.dart
+++ b/flutter_cache_manager/lib/src/web/web_helper.dart
@@ -153,6 +153,7 @@ class WebHelper {
       FileSource.Online,
       newCacheObject.validTill,
       newCacheObject.url,
+      statusCode: response.statusCode,
     );
   }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? 
feature

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?
The user can't override etag

### :boom: Does this PR introduce a breaking change?
no


### :bug: Recommendations for testing
no


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
