### PR TITLE
Fix bucket is null because of variable shadowing

### DIFF
--- a/flutter_cache_manager_firebase/lib/src/firebase_cache_manager.dart
+++ b/flutter_cache_manager_firebase/lib/src/firebase_cache_manager.dart
@@ -9,15 +9,15 @@ class FirebaseCacheManager extends CacheManager {
   static const key = 'firebaseCache';
 
   static final FirebaseCacheManager _instance =
-      FirebaseCacheManager._(retryOptions: retryOptions, bucket: bucket);
+      FirebaseCacheManager._(retryOptions: _retryOptions, bucket: _bucket);
 
-  static RetryOptions? retryOptions;
+  static RetryOptions? _retryOptions;
 
-  static String? bucket;
+  static String? _bucket;
 
   factory FirebaseCacheManager({RetryOptions? retryOptions, String? bucket}) {
-    bucket = bucket;
-    retryOptions = retryOptions;
+    _bucket = bucket;
+    _retryOptions = retryOptions;
     return _instance;
   }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? In recent version of Dart/Flutter (3.5.1/3.24.2), the bucket is null even when it is assigned.


### :arrow_heading_down: What is the current behavior? 
Bucket is null even when the value is passed

### :new: What is the new behavior (if this is a feature change)?
Make sure the bucket is not null when it is passed at inititalization

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
