### PR TITLE
Clear cache filesystem when emptying the store cache

### DIFF
--- a/flutter_cache_manager/lib/src/storage/file_system/file_system.dart
+++ b/flutter_cache_manager/lib/src/storage/file_system/file_system.dart
@@ -4,6 +4,10 @@ export 'file_system_web.dart';
 
 import 'package:file/file.dart';
 
+/// FileSystem works in the context of a directory where filenames are stored.
 abstract class FileSystem {
   Future<File> createFile(String name);
+
+  /// Deletes the directory that contains all the cached filed in the current context.
+  Future<void> deleteCacheDir();
 }

--- a/flutter_cache_manager/lib/src/storage/file_system/file_system_io.dart
+++ b/flutter_cache_manager/lib/src/storage/file_system/file_system_io.dart
@@ -28,4 +28,13 @@ class IOFileSystem implements FileSystem {
     }
     return directory.childFile(name);
   }
+
+  @override
+  Future<void> deleteCacheDir() async {
+    final directory = await _fileDir;
+
+    if (await directory.exists()) {
+      await directory.delete(recursive: true);
+    }
+  }
 }

--- a/flutter_cache_manager/lib/src/storage/file_system/file_system_web.dart
+++ b/flutter_cache_manager/lib/src/storage/file_system/file_system_web.dart
@@ -9,4 +9,12 @@ class MemoryCacheSystem implements FileSystem {
   Future<File> createFile(String name) async {
     return (await directory).childFile(name);
   }
+
+  @override
+  Future<void> deleteCacheDir() async {
+    final dir = await directory;
+    if (await dir.exists()) {
+      await dir.delete(recursive: true);
+    }
+  }
 }

--- a/flutter_cache_manager/lib/src/storage/file_system/file_system_web.dart
+++ b/flutter_cache_manager/lib/src/storage/file_system/file_system_web.dart
@@ -1,18 +1,31 @@
-import 'package:file/file.dart' show File;
+import 'package:file/file.dart' show File, Directory;
 import 'package:file/memory.dart';
 import 'package:flutter_cache_manager/src/storage/file_system/file_system.dart';
 
 class MemoryCacheSystem implements FileSystem {
-  final directory = MemoryFileSystem().systemTempDirectory.createTemp('cache');
+  Future<Directory> _fileDir;
+
+  MemoryCacheSystem() : _fileDir = _createTempDirectory();
 
   @override
   Future<File> createFile(String name) async {
-    return (await directory).childFile(name);
+    Directory directory = await _fileDir;
+    if (!(await directory.exists())) {
+      // Because _createTempDirectory assigns a new name we need to reassing the future
+      _fileDir = _createTempDirectory();
+      directory = await _fileDir;
+    }
+
+    return directory.childFile(name);
+  }
+
+  static Future<Directory> _createTempDirectory() async {
+    return MemoryFileSystem().systemTempDirectory.createTemp('cache');
   }
 
   @override
   Future<void> deleteCacheDir() async {
-    final dir = await directory;
+    final dir = await _fileDir;
     if (await dir.exists()) {
       await dir.delete(recursive: true);
     }

--- a/flutter_cache_manager/test/helpers/test_configuration.dart
+++ b/flutter_cache_manager/test/helpers/test_configuration.dart
@@ -25,4 +25,12 @@ class TestFileSystem extends FileSystem {
     await dir.create(recursive: true);
     return dir.childFile(name);
   }
+
+  @override
+  Future<void> deleteCacheDir() async {
+    var dir = await directoryFuture;
+    if (await dir.exists()) {
+      await dir.delete(recursive: true);
+    }
+  }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When there is a desync between the filesystem and the store those files are never cleaned up, filling up the filesystem. This desync can happen because of bugs in the library like the ones listed in #476. 

### :new: What is the new behavior (if this is a feature change)?
When calling `emptyCache` we can also clean up the cache directory associated to the store to clean up dangling files as well.

### :boom: Does this PR introduce a breaking change?

It adds a method to the file system interface.

### :bug: Recommendations for testing

Previously files were not deleted when calling `removeFile()`, so it only affects extra dangling files in the cache store. 
So to test it just add an extra file and call emptyCache.The current emptyCache test has been tweaked to account for this behavior.


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
