### PR TITLE
Add partial data handling (ie. Progressive JPEG)

### DIFF
--- a/flutter_cache_manager/lib/src/result/interlaced_progress.dart
+++ b/flutter_cache_manager/lib/src/result/interlaced_progress.dart
@@ -1,0 +1,10 @@
+import 'dart:typed_data';
+
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+
+class InterlacedProgress extends DownloadProgress {
+  InterlacedProgress(
+      super.originalUrl, super.totalSize, super.downloaded, this.data);
+
+  final Uint8List data;
+}

--- a/flutter_cache_manager/lib/src/result/result.dart
+++ b/flutter_cache_manager/lib/src/result/result.dart
@@ -1,3 +1,4 @@
 export 'download_progress.dart';
 export 'file_info.dart';
 export 'file_response.dart';
+export 'interlaced_progress.dart';

--- a/flutter_cache_manager/lib/src/web/interlaced/interlaced_transformer.dart
+++ b/flutter_cache_manager/lib/src/web/interlaced/interlaced_transformer.dart
@@ -1,0 +1,76 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_cache_manager/src/web/interlaced/progressive_jpeg_decoder.dart';
+
+class InterlacedData {
+  final Uint8List data;
+  InterlacedData(this.data);
+}
+
+class InterlacedConverter extends Converter<List<int>, InterlacedData> {
+  const InterlacedConverter();
+
+  @override
+  InterlacedData convert(List<int> input) =>
+      InterlacedData(Uint8List.fromList(input));
+
+  @override
+  Sink<Uint8List> startChunkedConversion(Sink<InterlacedData> sink) =>
+      InterlacedByteConversionSink(sink);
+}
+
+class InterlacedByteConversionSink implements ChunkedConversionSink<Uint8List> {
+  final Sink<InterlacedData> _output;
+
+  // Buffer to accumulate chunks
+  BytesBuilder? _buffer = BytesBuilder();
+
+  InterlacedDecoder? _decoder;
+
+  InterlacedByteConversionSink(this._output);
+
+  @override
+  void add(List<int> chunk) {
+    // Ensure buffer is not null (should not happen in normal flow)
+    final buffer = _buffer;
+    if (buffer == null) {
+      throw StateError('Sink has been closed and cannot accept new data.');
+    }
+
+    _decoder ??= resolveDecoder();
+
+    if (_decoder == null) {
+      return _buffer!.add(chunk);
+    }
+
+    final interlacedData = _decoder?.addChunk(chunk);
+    if (interlacedData != null) {
+      _output.add(interlacedData);
+    }
+  }
+
+  @override
+  void close() {
+    _buffer?.clear();
+    _buffer = null;
+    _decoder = null;
+    _output.close();
+  }
+
+  InterlacedDecoder? resolveDecoder() {
+    if (ProgressiveJPEGDecoder.isProgressiveJPEG(_buffer)) {
+      return ProgressiveJPEGDecoder(_buffer!);
+    }
+    return null;
+  }
+}
+
+// Base class for interlaced format decoders
+abstract class InterlacedDecoder {
+  final BytesBuilder buffer;
+
+  InterlacedDecoder(this.buffer);
+
+  InterlacedData? addChunk(List<int> chunk);
+}

--- a/flutter_cache_manager/lib/src/web/interlaced/interlaced_transformer.dart
+++ b/flutter_cache_manager/lib/src/web/interlaced/interlaced_transformer.dart
@@ -20,6 +20,17 @@ class InterlacedConverter extends Converter<List<int>, InterlacedData> {
       InterlacedByteConversionSink(sink);
 }
 
+/// Represents a decoder check function and its corresponding decoder constructor
+class DecoderCheck {
+  final bool? Function(BytesBuilder) check;
+  final InterlacedDecoder Function(BytesBuilder) createDecoder;
+
+  const DecoderCheck({
+    required this.check,
+    required this.createDecoder,
+  });
+}
+
 class InterlacedByteConversionSink implements ChunkedConversionSink<Uint8List> {
   final Sink<InterlacedData> _output;
 
@@ -27,6 +38,13 @@ class InterlacedByteConversionSink implements ChunkedConversionSink<Uint8List> {
   BytesBuilder? _buffer = BytesBuilder();
 
   InterlacedDecoder? _decoder;
+
+  static final _decoderChecks = [
+    DecoderCheck(
+      check: ProgressiveJPEGDecoder.isProgressiveJPEG,
+      createDecoder: (buffer) => ProgressiveJPEGDecoder(buffer),
+    ),
+  ];
 
   InterlacedByteConversionSink(this._output);
 
@@ -59,9 +77,31 @@ class InterlacedByteConversionSink implements ChunkedConversionSink<Uint8List> {
   }
 
   InterlacedDecoder? resolveDecoder() {
-    if (ProgressiveJPEGDecoder.isProgressiveJPEG(_buffer)) {
-      return ProgressiveJPEGDecoder(_buffer!);
+    // Try each decoder check
+    for (final decoderCheck in _decoderChecks) {
+      final result = decoderCheck.check(_buffer!);
+      if (result == true) {
+        return decoderCheck.createDecoder(_buffer!);
+      }
     }
+
+    // Check if all decoders returned false
+    if (_decoderChecks.every(
+      (check) => check.check(_buffer!) == false,
+    )) {
+      return DumbDecoder(_buffer!);
+    }
+
+    return null;
+  }
+}
+
+class DumbDecoder extends InterlacedDecoder {
+  DumbDecoder(super.buffer);
+
+  @override
+  InterlacedData? addChunk(List<int> chunk) {
+    buffer.add(chunk);
     return null;
   }
 }

--- a/flutter_cache_manager/lib/src/web/interlaced/progressive_jpeg_decoder.dart
+++ b/flutter_cache_manager/lib/src/web/interlaced/progressive_jpeg_decoder.dart
@@ -1,0 +1,73 @@
+import 'dart:typed_data';
+
+import 'package:flutter_cache_manager/src/web/interlaced/interlaced_transformer.dart';
+
+// Decoder for progressive JPEG images
+class ProgressiveJPEGDecoder extends InterlacedDecoder {
+  static bool isProgressiveJPEG(BytesBuilder? buffer) {
+    if (buffer == null) return false;
+
+    final data = buffer.toBytes();
+
+    if (data.length < 4) return false;
+
+    // Check for the SOI (Start of Image)
+    if (data[0] == 0xFF && data[1] == 0xD8) {
+      // Check for the first SOF marker
+      for (int i = 2; i < data.length - 1; i++) {
+        if (data[i] == 0xFF && data[i + 1] >= 0xC0 && data[i + 1] <= 0xCF) {
+          return data[i + 1] == 0xC2;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  // List of valid offsets
+  final List<int> _validOffsets = [];
+
+  ProgressiveJPEGDecoder(super.buffer);
+
+  @override
+  InterlacedData? addChunk(List<int> chunk) {
+    // Calculate startOffset before adding the new chunk
+    int startOffset =
+        (buffer.length - 1).clamp(0, buffer.length); // Ensure valid bounds
+
+    // Add the new chunk to the buffer
+    buffer.add(chunk);
+
+    _updateOffsets(buffer.toBytes(), startOffset);
+
+    return _getBestData();
+  }
+
+  InterlacedData? _getBestData() {
+    // Get the best valid data using the latest valid offset
+    if (_validOffsets.isNotEmpty) {
+      final data =
+          Uint8List.sublistView(buffer.toBytes(), 0, _validOffsets.last);
+
+      data[data.length - 1] = 0xd9; // Fix the last byte as EOI
+      return InterlacedData(data);
+    }
+
+    return null;
+  }
+
+  void _updateOffsets(Uint8List data, int startOffset) {
+    // Iterate through data starting from the adjusted offset
+    for (int i = startOffset; i < data.length - 1; i++) {
+      if (data[i] == 0xFF && _isMarker(data[i + 1])) {
+        // Add offset of the marker's end
+        _validOffsets.add(i + 2);
+      }
+    }
+  }
+
+  bool _isMarker(int byte) {
+    // Check for JPEG markers: 0xDA (Start of Scan) or 0xD9 (End of Image)
+    return byte == 0xDA || byte == 0xD9;
+  }
+}

--- a/flutter_cache_manager/lib/src/web/interlaced/progressive_jpeg_decoder.dart
+++ b/flutter_cache_manager/lib/src/web/interlaced/progressive_jpeg_decoder.dart
@@ -4,24 +4,29 @@ import 'package:flutter_cache_manager/src/web/interlaced/interlaced_transformer.
 
 // Decoder for progressive JPEG images
 class ProgressiveJPEGDecoder extends InterlacedDecoder {
-  static bool isProgressiveJPEG(BytesBuilder? buffer) {
-    if (buffer == null) return false;
+  /// Returns true if the buffer is a progressive JPEG image
+  /// Returns false if the buffer is not a progressive JPEG image
+  /// Returns null if the buffer is not enough to determine if it is a progressive JPEG image
+  static bool? isProgressiveJPEG(BytesBuilder? buffer) {
+    if (buffer == null) return null;
 
     final data = buffer.toBytes();
 
-    if (data.length < 4) return false;
+    if (data.length < 4) return null;
 
     // Check for the SOI (Start of Image)
-    if (data[0] == 0xFF && data[1] == 0xD8) {
-      // Check for the first SOF marker
-      for (int i = 2; i < data.length - 1; i++) {
-        if (data[i] == 0xFF && data[i + 1] >= 0xC0 && data[i + 1] <= 0xCF) {
-          return data[i + 1] == 0xC2;
-        }
+    if (data[0] != 0xFF || data[1] != 0xD8) {
+      return false;
+    }
+
+    // Check for the first SOF marker
+    for (int i = 2; i < data.length - 1; i++) {
+      if (data[i] == 0xFF && data[i + 1] >= 0xC0 && data[i + 1] <= 0xCF) {
+        return data[i + 1] == 0xC2;
       }
     }
 
-    return false;
+    return null;
   }
 
   // List of valid offsets


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This PR Introduces Progressive JPEG loading and prepare the handling of other "progressive" formats

### :arrow_heading_down: What is the current behavior?
This package don't provide partial data during the download, therefore it's impossible to use partial data for compatible files

### :new: What is the new behavior (if this is a feature change)?
I added a new FileResponse type that extends DownloadProgress but contains usable partial data in it

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
[Issue #43 in flutter_cached_network_image](https://github.com/Baseflow/flutter_cached_network_image/issues/43)

### :thinking: Checklist before submitting

- [ ] Check memory efficiency 
- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [ ] Rebased onto current 

PS: This is my first try at publicly contributing to a repo, any feedback would be appreciated