### PR TITLE
Add `timeout` parameter for downloading

### DIFF
--- a/flutter_cache_manager/lib/src/cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_manager.dart
@@ -98,6 +98,8 @@ class CacheManager implements BaseCacheManager {
 
   /// Get the file from the cache and/or online, depending on availability and age.
   /// Downloaded form [url], [headers] can be used for example for authentication.
+  /// [timeout] can be used to specify a timeout for the download, and it will throw
+  /// a [TimeoutException] when the download takes longer than the specified timeout.
   /// The files are returned as stream. First the cached file if available, when the
   /// cached file is too old the newly downloaded file is returned afterwards.
   ///

--- a/flutter_cache_manager/lib/src/cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_manager.dart
@@ -108,11 +108,17 @@ class CacheManager implements BaseCacheManager {
   /// returned from the cache there will be no progress given, although the file
   /// might be outdated and a new file is being downloaded in the background.
   @override
-  Stream<FileResponse> getFileStream(String url,
-      {String? key, Map<String, String>? headers, bool withProgress = false}) {
+  Stream<FileResponse> getFileStream(
+    String url, {
+    String? key,
+    Map<String, String>? headers,
+    Duration? timeout,
+    bool withProgress = false,
+  }) {
     key ??= url;
     final streamController = StreamController<FileResponse>();
-    _pushFileToStream(streamController, url, key, headers, withProgress);
+    _pushFileToStream(
+        streamController, url, key, headers, timeout, withProgress);
     return streamController.stream;
   }
 
@@ -121,6 +127,7 @@ class CacheManager implements BaseCacheManager {
     String url,
     String? key,
     Map<String, String>? headers,
+    Duration? timeout,
     bool withProgress,
   ) async {
     key ??= url;
@@ -139,7 +146,7 @@ class CacheManager implements BaseCacheManager {
     if (cacheFile == null || cacheFile.validTill.isBefore(DateTime.now())) {
       try {
         await for (final response
-            in _webHelper.downloadFile(url, key: key, authHeaders: headers)) {
+            in _webHelper.downloadFile(url, key: key, authHeaders: headers, timeout: timeout)) {
           if (response is DownloadProgress && withProgress) {
             streamController.add(response);
           }
@@ -173,6 +180,7 @@ class CacheManager implements BaseCacheManager {
   Future<FileInfo> downloadFile(String url,
       {String? key,
       Map<String, String>? authHeaders,
+      Duration? timeout,
       bool force = false}) async {
     key ??= url;
     final fileResponse = await _webHelper
@@ -180,6 +188,7 @@ class CacheManager implements BaseCacheManager {
           url,
           key: key,
           authHeaders: authHeaders,
+          timeout: timeout,
           ignoreMemCache: force,
         )
         .firstWhere((r) => r is FileInfo);

--- a/flutter_cache_manager/lib/src/cache_managers/base_cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_managers/base_cache_manager.dart
@@ -28,7 +28,8 @@ abstract class BaseCacheManager {
 
   /// Get the file from the cache and/or online, depending on availability and age.
   /// Downloaded form [url], [headers] can be used for example for authentication.
-  /// [timeout] can be used to specify a timeout for the download.
+  /// [timeout] can be used to specify a timeout for the download, and it will throw
+  /// a [TimeoutException] when the download takes longer than the specified timeout.
   /// The files are returned as stream. First the cached file if available, when the
   /// cached file is too old the newly downloaded file is returned afterwards.
   ///

--- a/flutter_cache_manager/lib/src/cache_managers/base_cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_managers/base_cache_manager.dart
@@ -28,6 +28,7 @@ abstract class BaseCacheManager {
 
   /// Get the file from the cache and/or online, depending on availability and age.
   /// Downloaded form [url], [headers] can be used for example for authentication.
+  /// [timeout] can be used to specify a timeout for the download.
   /// The files are returned as stream. First the cached file if available, when the
   /// cached file is too old the newly downloaded file is returned afterwards.
   ///
@@ -38,11 +39,17 @@ abstract class BaseCacheManager {
   /// returned from the cache there will be no progress given, although the file
   /// might be outdated and a new file is being downloaded in the background.
   Stream<FileResponse> getFileStream(String url,
-      {String? key, Map<String, String>? headers, bool withProgress});
+      {String? key,
+      Map<String, String>? headers,
+      Duration? timeout,
+      bool withProgress});
 
   ///Download the file and add to cache
   Future<FileInfo> downloadFile(String url,
-      {String? key, Map<String, String>? authHeaders, bool force = false});
+      {String? key,
+      Map<String, String>? authHeaders,
+      Duration? timeout,
+      bool force = false});
 
   /// Get the file from the cache.
   /// Specify [ignoreMemCache] to force a re-read from the database

--- a/flutter_cache_manager/lib/src/cache_managers/image_cache_manager.dart
+++ b/flutter_cache_manager/lib/src/cache_managers/image_cache_manager.dart
@@ -21,13 +21,19 @@ mixin ImageCacheManager on BaseCacheManager {
     String url, {
     String? key,
     Map<String, String>? headers,
+    Duration? timeout,
     bool withProgress = false,
     int? maxHeight,
     int? maxWidth,
   }) async* {
     if (maxHeight == null && maxWidth == null) {
-      yield* getFileStream(url,
-          key: key, headers: headers, withProgress: withProgress);
+      yield* getFileStream(
+        url,
+        key: key,
+        headers: headers,
+        timeout: timeout,
+        withProgress: withProgress,
+      );
       return;
     }
     key ??= url;

--- a/flutter_cache_manager/lib/src/compat/file_service_compat.dart
+++ b/flutter_cache_manager/lib/src/compat/file_service_compat.dart
@@ -11,9 +11,12 @@ class FileServiceCompat extends FileService {
 
   @override
   Future<FileServiceResponse> get(String url,
-      {Map<String, String>? headers}) async {
-    final legacyResponse = await fileFetcher(url, headers: headers);
-    return CompatFileServiceGetResponse(legacyResponse);
+      {Map<String, String>? headers, Duration? timeout}) async {
+    var legacyResponse = fileFetcher(url, headers: headers);
+    if (timeout != null) {
+      legacyResponse = legacyResponse.timeout(timeout);
+    }
+    return CompatFileServiceGetResponse(await legacyResponse);
   }
 }
 

--- a/flutter_cache_manager/lib/src/web/file_service.dart
+++ b/flutter_cache_manager/lib/src/web/file_service.dart
@@ -16,7 +16,11 @@ import 'package:http/http.dart' as http;
 abstract class FileService {
   int concurrentFetches = 10;
 
-  Future<FileServiceResponse> get(String url, {Map<String, String>? headers});
+  Future<FileServiceResponse> get(
+    String url, {
+    Map<String, String>? headers,
+    Duration? timeout,
+  });
 }
 
 /// [HttpFileService] is the most common file service and the default for
@@ -29,14 +33,18 @@ class HttpFileService extends FileService {
 
   @override
   Future<FileServiceResponse> get(String url,
-      {Map<String, String>? headers}) async {
+      {Map<String, String>? headers, Duration? timeout}) async {
     final req = http.Request('GET', Uri.parse(url));
     if (headers != null) {
       req.headers.addAll(headers);
     }
-    final httpResponse = await _httpClient.send(req);
 
-    return HttpGetResponse(httpResponse);
+    var streamedResponse = _httpClient.send(req);
+    if (timeout != null) {
+      streamedResponse = streamedResponse.timeout(timeout);
+    }
+
+    return HttpGetResponse(await streamedResponse);
   }
 }
 

--- a/flutter_cache_manager/lib/src/web/web_helper.dart
+++ b/flutter_cache_manager/lib/src/web/web_helper.dart
@@ -32,13 +32,14 @@ class WebHelper {
   Stream<FileResponse> downloadFile(String url,
       {String? key,
       Map<String, String>? authHeaders,
+      Duration? timeout,
       bool ignoreMemCache = false}) {
     key ??= url;
     var subject = _memCache[key];
     if (subject == null || ignoreMemCache) {
       subject = BehaviorSubject<FileResponse>();
       _memCache[key] = subject;
-      _downloadOrAddToQueue(url, key, authHeaders);
+      _downloadOrAddToQueue(url, key, authHeaders, timeout);
     }
     return subject.stream;
   }
@@ -49,6 +50,7 @@ class WebHelper {
     String url,
     String key,
     Map<String, String>? authHeaders,
+    Duration? timeout,
   ) async {
     //Add to queue if there are too many calls.
     if (concurrentCalls >= fileFetcher.concurrentFetches) {
@@ -61,8 +63,8 @@ class WebHelper {
     concurrentCalls++;
     final subject = _memCache[key]!;
     try {
-      await for (final result
-          in _updateFile(url, key, authHeaders: authHeaders)) {
+      await for (final result in _updateFile(url, key,
+          authHeaders: authHeaders, timeout: timeout)) {
         subject.add(result);
       }
     } on Object catch (e, stackTrace) {
@@ -71,19 +73,19 @@ class WebHelper {
       concurrentCalls--;
       await subject.close();
       _memCache.remove(key);
-      _checkQueue();
+      _checkQueue(timeout);
     }
   }
 
-  void _checkQueue() {
+  void _checkQueue(Duration? timeout) {
     if (_queue.isEmpty) return;
     final next = _queue.removeFirst();
-    _downloadOrAddToQueue(next.url, next.key, next.headers);
+    _downloadOrAddToQueue(next.url, next.key, next.headers, timeout);
   }
 
   ///Download the file from the url
   Stream<FileResponse> _updateFile(String url, String key,
-      {Map<String, String>? authHeaders}) async* {
+      {Map<String, String>? authHeaders, Duration? timeout}) async* {
     var cacheObject = await _store.retrieveCacheData(key);
     cacheObject = cacheObject == null
         ? CacheObject(
@@ -93,12 +95,15 @@ class WebHelper {
             relativePath: '${const Uuid().v1()}.file',
           )
         : cacheObject.copyWith(url: url);
-    final response = await _download(cacheObject, authHeaders);
+    final response = await _download(cacheObject, authHeaders, timeout);
     yield* _manageResponse(cacheObject, response);
   }
 
   Future<FileServiceResponse> _download(
-      CacheObject cacheObject, Map<String, String>? authHeaders) {
+    CacheObject cacheObject,
+    Map<String, String>? authHeaders,
+    Duration? timeout,
+  ) {
     final headers = <String, String>{};
 
     final etag = cacheObject.eTag;
@@ -112,7 +117,7 @@ class WebHelper {
       headers.addAll(authHeaders);
     }
 
-    return fileFetcher.get(cacheObject.url, headers: headers);
+    return fileFetcher.get(cacheObject.url, headers: headers, timeout: timeout);
   }
 
   Stream<FileResponse> _manageResponse(

--- a/flutter_cache_manager/test/mock.mocks.dart
+++ b/flutter_cache_manager/test/mock.mocks.dart
@@ -443,12 +443,16 @@ class MockFileServiceBase extends _i1.Mock implements _i3.FileService {
   _i4.Future<_i3.FileServiceResponse> get(
     String? url, {
     Map<String, String>? headers,
+    Duration? timeout,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
           #get,
           [url],
-          {#headers: headers},
+          {
+            #headers: headers,
+            #timeout: timeout,
+          },
         ),
         returnValue: _i4.Future<_i3.FileServiceResponse>.value(
             _FakeFileServiceResponse_4(
@@ -456,7 +460,10 @@ class MockFileServiceBase extends _i1.Mock implements _i3.FileService {
           Invocation.method(
             #get,
             [url],
-            {#headers: headers},
+            {
+              #headers: headers,
+              #timeout: timeout,
+            },
           ),
         )),
       ) as _i4.Future<_i3.FileServiceResponse>);
@@ -499,6 +506,7 @@ class MockWebHelper extends _i1.Mock implements _i7.WebHelper {
     String? url, {
     String? key,
     Map<String, String>? authHeaders,
+    Duration? timeout,
     bool? ignoreMemCache = false,
   }) =>
       (super.noSuchMethod(
@@ -508,6 +516,7 @@ class MockWebHelper extends _i1.Mock implements _i7.WebHelper {
           {
             #key: key,
             #authHeaders: authHeaders,
+            #timeout: timeout,
             #ignoreMemCache: ignoreMemCache,
           },
         ),


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

This PR is to resolve #141, supporting pass `timeout` for downloading.

### :arrow_heading_down: What is the current behavior?

There is no way to set `timeout`.

### :new: What is the new behavior (if this is a feature change)?

A `timeout` duration can be set, and the http request will be timeouted after the duration (a `TimeoutException` will be thrown). If `timeout` is not set, all behaviors are same with the original.

### :boom: Does this PR introduce a breaking change?

N/A

### :bug: Recommendations for testing

1. Check if it will stop and throw a `TimeoutException` after the duration.
2. Check if the behavior is same as original when `timeout` is not set.

### :memo: Links to relevant issues/docs

Issue #141.

### :thinking: Checklist before submitting

- [ ] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
