### PR TITLE
Add error handling to cache store future operations

### DIFF
--- a/flutter_cache_manager/lib/src/cache_store.dart
+++ b/flutter_cache_manager/lib/src/cache_store.dart
@@ -84,6 +84,9 @@ class CacheStore {
         }
         completer.complete(cacheObject);
         _futureCache.remove(key);
+      }).catchError((err) {
+        completer.completeError(err);
+        _futureCache.remove(key);
       });
       _futureCache[key] = completer.future;
     }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When database operations in the `retrieveCacheData` method encounter exceptions, error callbacks are not properly executed. Specifically:
- When `_getCacheDataFromDatabase` or related async operations throw exceptions, the `Completer` is not handled correctly
- Exceptions are not caught and propagated, preventing callers from receiving error callbacks
- Entries in `_futureCache` may not be properly cleaned up, causing memory leaks

### :new: What is the new behavior (if this is a feature change)?
After the fix:
- Added `catchError` handler to properly catch and propagate exceptions to the `completer`
- Ensures proper cleanup of `_futureCache` in both success and error paths
- Callers can now properly receive error callbacks in exception scenarios

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
- Simulate database connection exceptions to verify error callbacks are properly executed
- Test scenarios where `_fileExists` method throws exceptions
- Verify handling when `_cacheInfoRepository` access fails
- Confirm that `_futureCache` is properly cleaned up in exception cases

### :memo: Links to relevant issues/docs
N/A

### :thinking: Checklist before submitting
- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop