### PR TITLE
Fix cache file not deleted when remove cache file

### DIFF
--- a/flutter_cache_manager/lib/src/web/web_helper.dart
+++ b/flutter_cache_manager/lib/src/web/web_helper.dart
@@ -168,7 +168,7 @@ class WebHelper {
         _removeOldFile(filePath);
       }
       // Store new file on different path
-      filePath = '${const Uuid().v1()}$fileExtension';
+      filePath = '${const Uuid().v1()}.$fileExtension';
     }
     return cacheObject.copyWith(
       relativePath: filePath,


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix desync file between file system and the store file

### :arrow_heading_down: What is the current behavior?

the store file save the relative path without `.` separator, resulting desync between store file and filesystem

### :new: What is the new behavior (if this is a feature change)?

the store file include `.` separator in the relative path , reducing file desync 

### :boom: Does this PR introduce a breaking change?

no

### :bug: Recommendations for testing

-

### :memo: Links to relevant issues/docs

-

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
