### PR TITLE
Update example Android build for Flutter 3.44

### DIFF
--- a/flutter_cache_manager/CHANGELOG.md
+++ b/flutter_cache_manager/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+* Update example Android project for Flutter 3.44 (Gradle 9.1 / AGP 9.0.1 / Kotlin 2.3.20, Java 17)
+* Migrate example Android app to built-in Kotlin
+
 ## [3.4.1] - 2024-08-13
 
 * Target js_interop for Wasm support

--- a/flutter_cache_manager/example/android/app/build.gradle
+++ b/flutter_cache_manager/example/android/app/build.gradle
@@ -5,32 +5,18 @@ plugins {
     id "dev.flutter.flutter-gradle-plugin"
 }
 
-def localProperties = new Properties()
-def localPropertiesFile = rootProject.file("local.properties")
-if (localPropertiesFile.exists()) {
-    localPropertiesFile.withReader("UTF-8") { reader ->
-        localProperties.load(reader)
-    }
-}
-
-def flutterVersionCode = localProperties.getProperty("flutter.versionCode")
-if (flutterVersionCode == null) {
-    flutterVersionCode = "1"
-}
-
-def flutterVersionName = localProperties.getProperty("flutter.versionName")
-if (flutterVersionName == null) {
-    flutterVersionName = "1.0"
-}
-
 android {
     namespace = "com.example.example"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     defaultConfig {
@@ -40,8 +26,8 @@ android {
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
-        versionCode = flutterVersionCode.toInteger()
-        versionName = flutterVersionName
+        versionCode = flutter.versionCode
+        versionName = flutter.versionName
     }
 
     buildTypes {

--- a/flutter_cache_manager/example/android/app/build.gradle
+++ b/flutter_cache_manager/example/android/app/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
-    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
+    // The Flutter Gradle Plugin must be applied after the Android Gradle plugin.
     id "dev.flutter.flutter-gradle-plugin"
 }
 
@@ -13,10 +12,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
     }
 
     defaultConfig {
@@ -36,6 +31,12 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.debug
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/flutter_cache_manager/example/android/gradle.properties
+++ b/flutter_cache_manager/example/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx4G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/flutter_cache_manager/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/flutter_cache_manager/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip

--- a/flutter_cache_manager/example/android/settings.gradle
+++ b/flutter_cache_manager/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+    id "com.android.application" version "9.0.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.3.20" apply false
 }
 
 include ":app"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Chore / build tooling update for the example Android app.

### :arrow_heading_down: What is the current behavior?

The example Android project uses an outdated toolchain (Gradle 7.6.3, AGP 7.3.0, Kotlin 1.7.10, Java 8). Building with Flutter 3.44 fails with:

`Language version 1.4 is no longer supported; please, use version 1.8 or greater.`

The example also still applies the Kotlin Gradle Plugin (`kotlin-android`), which Flutter warns will break in a future release.

### :new: What is the new behavior (if this is a feature change)?

- Bumps the example Android toolchain to Gradle 9.1.0, AGP 9.0.1, Kotlin 2.3.20, and Java 17
- Migrates the example app to AGP built-in Kotlin (`kotlin.compilerOptions`) per Flutter’s migration guide
- Adds Flutter’s compatibility flags (`android.builtInKotlin=false`, `android.newDsl=false`) in `gradle.properties`

### :boom: Does this PR introduce a breaking change?

No. Changes are limited to the example Android project.

### :bug: Recommendations for testing

- From `flutter_cache_manager/example`, run `flutter build apk --release`
- Confirm the build succeeds without the Kotlin language-version error or KGP warning

### :memo: Links to relevant issues/docs

- https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers
- https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop