### PR TITLE
Update flutter_cache_manager_firebase dependencies

### DIFF
--- a/flutter_cache_manager_firebase/CHANGELOG.md
+++ b/flutter_cache_manager_firebase/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.1.3] - 2026-07-21
+
+* Raises minimum Dart SDK to 3.10.0
+* Updates dependencies
+* Supports firebase_storage 13.x (constraint widened to `<14.0.0`)
+
 ## [2.1.2] - 2026-07-21
 
 * Fixes `bucket` and `retryOptions` being ignored due to variable shadowing.

--- a/flutter_cache_manager_firebase/lib/flutter_cache_manager_firebase.dart
+++ b/flutter_cache_manager_firebase/lib/flutter_cache_manager_firebase.dart
@@ -1,4 +1,2 @@
-library flutter_cache_manager_firebase;
-
 export 'src/firebase_cache_manager.dart';
 export 'src/firebase_http_file_service.dart';

--- a/flutter_cache_manager_firebase/lib/src/firebase_cache_manager.dart
+++ b/flutter_cache_manager_firebase/lib/src/firebase_cache_manager.dart
@@ -8,8 +8,10 @@ import 'firebase_http_file_service.dart';
 class FirebaseCacheManager extends CacheManager {
   static const key = 'firebaseCache';
 
-  static final FirebaseCacheManager _instance =
-      FirebaseCacheManager._(retryOptions: _retryOptions, bucket: _bucket);
+  static final FirebaseCacheManager _instance = FirebaseCacheManager._(
+    retryOptions: _retryOptions,
+    bucket: _bucket,
+  );
 
   static RetryOptions? _retryOptions;
 
@@ -22,7 +24,13 @@ class FirebaseCacheManager extends CacheManager {
   }
 
   FirebaseCacheManager._({RetryOptions? retryOptions, String? bucket})
-      : super(Config(key,
-            fileService: FirebaseHttpFileService(
-                retryOptions: retryOptions, bucket: bucket)));
+    : super(
+        Config(
+          key,
+          fileService: FirebaseHttpFileService(
+            retryOptions: retryOptions,
+            bucket: bucket,
+          ),
+        ),
+      );
 }

--- a/flutter_cache_manager_firebase/lib/src/firebase_http_file_service.dart
+++ b/flutter_cache_manager_firebase/lib/src/firebase_http_file_service.dart
@@ -8,20 +8,20 @@ import 'package:retry/retry.dart';
 class FirebaseHttpFileService extends HttpFileService {
   final RetryOptions? retryOptions;
 
-  FirebaseHttpFileService({
-    this.retryOptions,
-    this.bucket,
-  }) : super();
+  FirebaseHttpFileService({this.retryOptions, this.bucket}) : super();
 
   final String? bucket;
 
   @override
-  Future<FileServiceResponse> get(String url,
-      {Map<String, String>? headers}) async {
+  Future<FileServiceResponse> get(
+    String url, {
+    Map<String, String>? headers,
+  }) async {
     late Reference ref;
     if (bucket != null) {
-      ref =
-          FirebaseStorage.instanceFor(bucket: "gs://$bucket").ref().child(url);
+      ref = FirebaseStorage.instanceFor(
+        bucket: "gs://$bucket",
+      ).ref().child(url);
     } else {
       ref = FirebaseStorage.instance.ref().child(url);
     }

--- a/flutter_cache_manager_firebase/pubspec.yaml
+++ b/flutter_cache_manager_firebase/pubspec.yaml
@@ -1,21 +1,21 @@
 name: flutter_cache_manager_firebase
 description: CacheManager implementation for firebase_storage. Uses the gs:// as key and translates to https://
-version: 2.1.2
+version: 2.1.3
 homepage: https://github.com/Baseflow/flutter_cache_manager
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_cache_manager: ^3.4.1
-  firebase_storage: '>=12.0.0 <13.0.0'
-  path_provider: ^2.1.4
-  path: ^1.9.0
+  flutter_cache_manager: ^3.4.2
+  firebase_storage: '>=12.0.0 <14.0.0'
+  path_provider: ^2.1.6
+  path: ^1.9.1
   retry: ^3.1.2
 
 dev_dependencies:
-  flutter_lints: ^4.0.0
+  flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Dependency and SDK update for `flutter_cache_manager_firebase` (v2.1.3).

### :arrow_heading_down: What is the current behavior?

- Min Dart SDK is `>=3.0.0`
- `flutter_cache_manager` constrained to `^3.4.1`
- `firebase_storage` constrained to `>=12.0.0 <13.0.0`
- `flutter_lints` at `^4.0.0`
- Other deps (`path_provider`, `path`) slightly behind latest compatible versions

### :new: What is the new behavior (if this is a feature change)?

- Raises min Dart SDK to `>=3.10.0`
- Updates `flutter_cache_manager` to `^3.4.2`
- Widens `firebase_storage` to `>=12.0.0 <14.0.0` (supports 13.x)
- Updates `path_provider` to `^2.1.6`, `path` to `^1.9.1`, `flutter_lints` to `^6.0.0`
- Removes unnecessary library name (new lint from flutter_lints 6)
- Applies dart format to source files

### :boom: Does this PR introduce a breaking change?

Yes for consumers still on Dart SDK &lt; 3.10.0. Apps already on Flutter with Dart 3.10+ are unaffected. `firebase_storage` 12.x remains supported.

### :bug: Recommendations for testing

- [ ] `flutter pub get` in `flutter_cache_manager_firebase`
- [ ] `dart format --set-exit-if-changed .`
- [ ] `flutter analyze`
- [ ] Confirm resolution works with both `firebase_storage` 12.x and 13.x if possible

### :memo: Links to relevant issues/docs

N/A

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop