### PR TITLE
Modernize GitHub Actions CI workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build-firebase.yaml
+++ b/.github/workflows/build-firebase.yaml
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FLUTTER_VERSION: "stable"
+  FLUTTER_VERSION: "3.44.4"
 
 jobs:
   quality:

--- a/.github/workflows/build-firebase.yaml
+++ b/.github/workflows/build-firebase.yaml
@@ -1,7 +1,5 @@
 name: build firebase
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the develop branch
 on:
   workflow_dispatch:
 
@@ -11,153 +9,74 @@ on:
     branches: [develop, main]
     paths:
       - "flutter_cache_manager_firebase/**"
-      - ".github/workflows/**"
+      - ".github/workflows/build-firebase.yaml"
   pull_request:
     branches: [develop, main]
     paths:
       - "flutter_cache_manager_firebase/**"
-      - ".github/workflows/**"
+      - ".github/workflows/build-firebase.yaml"
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  FLUTTER_VERSION: "stable"
+
 jobs:
-  format:
-    name: Format
-
-    # The type of runner that the job will run on
+  quality:
+    name: Format, Analyze & Test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
-    env:
-      source-directory: ./flutter_cache_manager_firebase
+    defaults:
+      run:
+        working-directory: ./flutter_cache_manager_firebase
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      # Make sure the stable version of Flutter is available
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          architecture: x64
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
 
-      # Download all Flutter packages
       - name: Download dependencies
         run: flutter pub get
-        working-directory: ${{env.source-directory}}
 
-      # Run Flutter Format to ensure formatting is valid
-      - name: Run Flutter Format
+      - name: Run Dart Format
         run: dart format --set-exit-if-changed .
-        working-directory: ${{env.source-directory}}
 
-  analyze:
-    name: Analyze
-
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    env:
-      source-directory: ./flutter_cache_manager_firebase
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-
-      # Make sure the stable version of Flutter is available
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: "stable"
-          architecture: x64
-          cache: true
-
-      # Download all Flutter packages
-      - name: Download dependencies
-        run: flutter pub get
-        working-directory: ${{env.source-directory}}
-
-      # Run Flutter Analyzer
       - name: Run Flutter Analyzer
         run: flutter analyze
-        working-directory: ${{env.source-directory}}
 
-  tests:
-    name: Unit-tests
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    env:
-      source-directory: ./flutter_cache_manager_firebase
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-
-      # Make sure the stable version of Flutter is available
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: "stable"
-          architecture: x64
-          cache: true
-
-      # Download all Flutter packages
-      - name: Download dependencies
-        run: flutter pub get
-        working-directory: ${{env.source-directory}}
-
-      # Run all unit-tests with code coverage
-      # - name: Run unit tests
-      #   run: flutter test --coverage
-      #   working-directory: ${{env.source-directory}}
-
-      # # Upload code coverage information
-      # - uses: codecov/codecov-action@v4
-      #   env:
-      #      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      #   with:
-      #     files: ${{env.source-directory}}/coverage/lcov.info
-      #     name: CacheManager
-      #     fail_ci_if_error: true
+      - name: Run unit tests
+        run: flutter test --coverage
 
   publish_cache_manager_firebase:
     if: ${{ github.ref_type == 'tag' }}
     name: Publish Cache Manager Firebase
     permissions:
       id-token: write
-    needs: [format, analyze, tests]
-    # The type of runner that the job will run on
+      contents: read
+    needs: [quality]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
-    env:
-      source-directory: ./flutter_cache_manager_firebase
+    defaults:
+      run:
+        working-directory: ./flutter_cache_manager_firebase
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Dart
         uses: dart-lang/setup-dart@v1
 
-      # Make sure the stable version of Flutter is available
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: "stable"
-          architecture: x64
-          cache: true
-
-      # Download all Flutter packages
-      - name: Download dependencies
-        run: flutter pub get
-        working-directory: ${{env.source-directory}}
-
-      # Publish the package
       - name: Publish package
         run: dart pub publish -v -f
-        working-directory: ${{env.source-directory}}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FLUTTER_VERSION: "stable"
+  FLUTTER_VERSION: "3.44.4"
 
 jobs:
   quality:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,5 @@
 name: build
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the develop branch
 on:
   workflow_dispatch:
 
@@ -11,357 +9,231 @@ on:
     branches: [develop, main]
     paths:
       - "flutter_cache_manager/**"
-      - ".github/workflows/**"
+      - ".github/workflows/build.yaml"
   pull_request:
     branches: [develop, main]
     paths:
       - "flutter_cache_manager/**"
-      - ".github/workflows/**"
+      - ".github/workflows/build.yaml"
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  FLUTTER_VERSION: "stable"
+
 jobs:
-  format:
-    name: Format
-
-    # The type of runner that the job will run on
+  quality:
+    name: Format, Analyze & Test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
-    env:
-      source-directory: ./flutter_cache_manager
+    defaults:
+      run:
+        working-directory: ./flutter_cache_manager
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      # Make sure the stable version of Flutter is available
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          architecture: x64
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
 
-      # Download all Flutter packages
       - name: Download dependencies
         run: flutter pub get
-        working-directory: ${{env.source-directory}}
 
-      # Run Flutter Format to ensure formatting is valid
-      - name: Run Flutter Format
+      - name: Run Dart Format
         run: dart format --set-exit-if-changed .
-        working-directory: ${{env.source-directory}}
 
-  analyze:
-    name: Analyze
-
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    env:
-      source-directory: ./flutter_cache_manager
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-
-      # Make sure the stable version of Flutter is available
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: "stable"
-          architecture: x64
-          cache: true
-
-      # Download all Flutter packages
-      - name: Download dependencies
-        run: flutter pub get
-        working-directory: ${{env.source-directory}}
-
-      # Run Flutter Analyzer
       - name: Run Flutter Analyzer
         run: flutter analyze
-        working-directory: ${{env.source-directory}}
+
+      - name: Run unit tests
+        run: flutter test --coverage
 
   build_android:
     name: Build Android App
-
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
-    env:
-      source-directory: ./flutter_cache_manager
-      example-directory: ./flutter_cache_manager/example
+    defaults:
+      run:
+        working-directory: ./flutter_cache_manager
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      # Ensure correct JAVA version is installed.
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: "zulu"
           java-version: "17"
 
-      # Make sure the stable version of Flutter is available
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          architecture: x64
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
 
-      # Download all Flutter packages
       - name: Download dependencies
         run: flutter pub get
-        working-directory: ${{env.source-directory}}
 
-      # Build Android version of the example App
       - name: Run Android build
         run: flutter build apk --release
-        working-directory: ${{env.example-directory}}
+        working-directory: ./flutter_cache_manager/example
 
   build_ios:
     name: Build iOS App
-
-    # The type of runner that the job will run on
     runs-on: macos-latest
+    timeout-minutes: 60
 
-    env:
-      source-directory: ./flutter_cache_manager
-      example-directory: ./flutter_cache_manager/example
+    defaults:
+      run:
+        working-directory: ./flutter_cache_manager
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      # Make sure the stable version of Flutter is available
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          architecture: x64
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
 
-      # Download all Flutter packages
       - name: Download dependencies
         run: flutter pub get
-        working-directory: ${{env.source-directory}}
 
-      # Build iOS version of the example App
       - name: Run iOS build
         run: flutter build ios --release --no-codesign
-        working-directory: ${{env.example-directory}}
+        working-directory: ./flutter_cache_manager/example
 
   build_macOS:
     name: Build macOS App
-
-    # The type of runner that the job will run on
     runs-on: macos-latest
+    timeout-minutes: 60
 
-    env:
-      source-directory: ./flutter_cache_manager
-      example-directory: ./flutter_cache_manager/example
+    defaults:
+      run:
+        working-directory: ./flutter_cache_manager
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      # Make sure the stable version of Flutter is available
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          architecture: x64
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
 
-      # Enable platform support
-      - name: Enable macOS
-        run: flutter config --enable-macos-desktop
-        working-directory: ${{env.source-directory}}
-
-      # Download all Flutter packages
       - name: Download dependencies
         run: flutter pub get
-        working-directory: ${{env.source-directory}}
 
-      # Build macOS version of the example App
       - name: Run macOS build
         run: flutter build macos --release
-        working-directory: ${{env.example-directory}}
+        working-directory: ./flutter_cache_manager/example
 
   build_windows:
     name: Build Windows App
-
-    # The type of runner that the job will run on
     runs-on: windows-latest
+    timeout-minutes: 45
 
-    env:
-      source-directory: ./flutter_cache_manager
-      example-directory: ./flutter_cache_manager/example
+    defaults:
+      run:
+        working-directory: ./flutter_cache_manager
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      # Make sure the stable version of Flutter is available
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          architecture: x64
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
 
-      # Enable platform support
-      - name: Enable Windows
-        run: flutter config --enable-windows-desktop
-        working-directory: ${{env.source-directory}}
-
-      # Download all Flutter packages
       - name: Download dependencies
         run: flutter pub get
-        working-directory: ${{env.source-directory}}
 
-      # Build iOS version of the example App
       - name: Run Windows build
         run: flutter build windows --release
-        working-directory: ${{env.example-directory}}
+        working-directory: ./flutter_cache_manager/example
 
   build_linux:
     name: Build Linux App
-
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
-    env:
-      source-directory: ./flutter_cache_manager
-      example-directory: ./flutter_cache_manager/example
+    defaults:
+      run:
+        working-directory: ./flutter_cache_manager
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Install libraries for Linux
-      - run: sudo apt-get update -y
-      - run: sudo apt-get install -y ninja-build libgtk-3-dev libblkid-dev
+      - uses: actions/checkout@v5
 
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y ninja-build libgtk-3-dev
+        working-directory: .
 
-      # Make sure the stable version of Flutter is available
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          architecture: x64
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
 
-      # Enable platform support
-      - name: Enable Linux
-        run: flutter config --enable-linux-desktop
-        working-directory: ${{env.source-directory}}
-
-      # Enable platform support
-      - name: Flutter Doctor
-        run: flutter doctor
-        working-directory: ${{env.source-directory}}
-
-      # Download all Flutter packages
       - name: Download dependencies
         run: flutter pub get
-        working-directory: ${{env.source-directory}}
 
-      # Build iOS version of the example App
       - name: Run Linux build
         run: flutter build linux --release
-        working-directory: ${{env.example-directory}}
+        working-directory: ./flutter_cache_manager/example
 
   build_web:
     name: Build Web App
-
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
-    env:
-      source-directory: ./flutter_cache_manager
-      example-directory: ./flutter_cache_manager/example
+    defaults:
+      run:
+        working-directory: ./flutter_cache_manager
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      # Make sure the stable version of Flutter is available
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          architecture: x64
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
 
-      # Download all Flutter packages
       - name: Download dependencies
         run: flutter pub get
-        working-directory: ${{env.source-directory}}
 
-      # Build Web version of the example App
       - name: Run Web build
         run: flutter build web --release
-        working-directory: ${{env.example-directory}}
-
-  tests:
-    name: Unit-tests
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    env:
-      source-directory: ./flutter_cache_manager
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-
-      # Make sure the stable version of Flutter is available
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: "stable"
-          architecture: x64
-          cache: true
-
-      # Download all Flutter packages
-      - name: Download dependencies
-        run: flutter pub get
-        working-directory: ${{env.source-directory}}
-
-      # Run all unit-tests with code coverage
-      - name: Run unit tests
-        run: flutter test --coverage
-        working-directory: ${{env.source-directory}}
-
-      # # Upload code coverage information
-      # - uses: codecov/codecov-action@v4
-      #   env:
-      #      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      #   with:
-      #     files: ${{env.source-directory}}/coverage/lcov.info
-      #     name: CacheManager
-      #     fail_ci_if_error: true
+        working-directory: ./flutter_cache_manager/example
 
   publish_cache_manager:
     if: ${{ github.ref_type == 'tag' }}
     name: Publish CacheManager
     permissions:
       id-token: write
+      contents: read
     needs:
       [
-        format,
-        analyze,
-        tests,
+        quality,
         build_android,
         build_ios,
         build_macOS,
@@ -369,34 +241,18 @@ jobs:
         build_linux,
         build_web,
       ]
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
-    env:
-      source-directory: ./flutter_cache_manager
+    defaults:
+      run:
+        working-directory: ./flutter_cache_manager
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Dart
         uses: dart-lang/setup-dart@v1
 
-      # Make sure the stable version of Flutter is available
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: "stable"
-          architecture: x64
-          cache: true
-
-      # Download all Flutter packages
-      - name: Download dependencies
-        run: flutter pub get
-        working-directory: ${{env.source-directory}}
-
-      # Publish the package
       - name: Publish package
         run: dart pub publish -v -f
-        working-directory: ${{env.source-directory}}

--- a/flutter_cache_manager/CHANGELOG.md
+++ b/flutter_cache_manager/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+* Modernizes GitHub Actions CI (combined quality job, pinned Flutter 3.44.4, Dependabot for actions)
+* Updates example Android project to AGP 8.11.1 / Gradle 8.14 / Kotlin 2.2.20 for compatibility with current Flutter tooling and `jni`
+
 ## [3.4.2]
 
 * Fixes `removeFile` deleting from the wrong path

--- a/flutter_cache_manager/example/android/app/build.gradle
+++ b/flutter_cache_manager/example/android/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "com.android.application"
-    // The Flutter Gradle Plugin must be applied after the Android Gradle plugin.
+    id "kotlin-android"
+    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id "dev.flutter.flutter-gradle-plugin"
 }
 
@@ -12,6 +13,10 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     defaultConfig {
@@ -31,12 +36,6 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.debug
         }
-    }
-}
-
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/flutter_cache_manager/example/android/gradle.properties
+++ b/flutter_cache_manager/example/android/gradle.properties
@@ -1,7 +1,6 @@
 org.gradle.jvmargs=-Xmx4G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
-# This builtInKotlin flag was added automatically by Flutter migrator
+# Flutter migrator keeps these for AGP 8 / plugin compatibility
 android.builtInKotlin=false
-# This newDsl flag was added automatically by Flutter migrator
 android.newDsl=false

--- a/flutter_cache_manager/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/flutter_cache_manager/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/flutter_cache_manager/example/android/settings.gradle
+++ b/flutter_cache_manager/example/android/settings.gradle
@@ -18,8 +18,9 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "9.0.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.3.20" apply false
+    // Stay on AGP 8.x: AGP 9 + Flutter's builtInKotlin=false opt-out breaks jni 1.0.1
+    id "com.android.application" version "8.11.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/flutter_cache_manager_firebase/CHANGELOG.md
+++ b/flutter_cache_manager_firebase/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+* Modernizes GitHub Actions CI (combined quality job, pinned Flutter 3.44.4, Dependabot for actions)
+* Adds a smoke unit test so CI `flutter test` no longer exits with “No tests were found”
+
 ## [2.1.3] - 2026-07-21
 
 * Raises minimum Dart SDK to 3.10.0

--- a/flutter_cache_manager_firebase/test/flutter_cache_manager_firebase_test.dart
+++ b/flutter_cache_manager_firebase/test/flutter_cache_manager_firebase_test.dart
@@ -1,1 +1,8 @@
-void main() {}
+import 'package:flutter_cache_manager_firebase/flutter_cache_manager_firebase.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('FirebaseCacheManager key is set', () {
+    expect(FirebaseCacheManager.key, 'firebaseCache');
+  });
+}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

CI / tooling update for the GitHub Actions workflows and Dependabot.

### :arrow_heading_down: What is the current behavior?

- Workflows use older actions (`checkout@v4`, `setup-java@v4`)
- Format, analyze, and tests run as separate jobs with duplicated Flutter setup
- Firebase workflow has a no-op tests job (test step commented out)
- Desktop `flutter config` enable flags and `architecture: x64` are still set
- Publish jobs install both Dart and Flutter
- No concurrency, default permissions, job timeouts, or Dependabot for actions
- Path filters watch all of `.github/workflows/**`, so editing one workflow triggers the other

### :new: What is the new behavior (if this is a feature change)?

- Bump `actions/checkout` to `@v5` and `actions/setup-java` to `@v5`
- Merge format/analyze/tests into a single `quality` job with shared Flutter setup
- Re-enable Firebase unit tests; slim publish jobs to `dart-lang/setup-dart` only
- Remove obsolete desktop enable flags and `architecture: x64`
- Pin Flutter to `3.44.4`, add permissions/concurrency/timeouts
- Narrow path filters to each workflow file
- Add Dependabot for monthly `github-actions` updates

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

- [ ] Confirm the `build` workflow passes on this PR for `flutter_cache_manager` paths
- [ ] Confirm the `build firebase` workflow passes when Firebase paths change
- [ ] Spot-check that Dependabot is enabled for the repo after merge

### :memo: Links to relevant issues/docs

N/A — follow-up to CI hygiene recommendations for `.github/workflows/build.yaml` and `build-firebase.yaml`.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cache_manager/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop